### PR TITLE
Enable the addition of extra logstash-filters through extra bosh release

### DIFF
--- a/.final_builds/jobs/api/index.yml
+++ b/.final_builds/jobs/api/index.yml
@@ -7,4 +7,5 @@ builds:
   cfafecb25cac694ef36460c7b8785abe7ff06f0a:
     blobstore_id: f21dfcc9-53ae-4827-ac8f-ba668193a24a
     version: 2
-    sha1: f3409cf6229787d04924a6c06321ddf10cde304e
+    sha1: !binary |-
+      ZjM0MDljZjYyMjk3ODdkMDQ5MjRhNmMwNjMyMWRkZjEwY2RlMzA0ZQ==

--- a/.final_builds/jobs/collectd/index.yml
+++ b/.final_builds/jobs/collectd/index.yml
@@ -3,4 +3,5 @@ builds:
   ec57dd2ad0199c989dc17c3777187e88c51f2464:
     blobstore_id: 344dfba8-7b11-4851-8b25-1269b6335488
     version: 1
-    sha1: 4ef336c63015991e31d03bdef380db0e52c691ca
+    sha1: !binary |-
+      NGVmMzM2YzYzMDE1OTkxZTMxZDAzYmRlZjM4MGRiMGU1MmM2OTFjYQ==

--- a/.final_builds/jobs/elasticsearch/index.yml
+++ b/.final_builds/jobs/elasticsearch/index.yml
@@ -7,4 +7,5 @@ builds:
   aab64e5cdd256fe1eeffdfe4d7073efb54a18766:
     blobstore_id: 8117dfb1-e010-4e29-ae06-3bd3d535f5f5
     version: 2
-    sha1: f85060405a0d7d4c0bcdc463dd0d888216aa0b4e
+    sha1: !binary |-
+      Zjg1MDYwNDA1YTBkN2Q0YzBiY2RjNDYzZGQwZDg4ODIxNmFhMGI0ZQ==

--- a/.final_builds/jobs/ingestor_lumberjack/index.yml
+++ b/.final_builds/jobs/ingestor_lumberjack/index.yml
@@ -7,4 +7,5 @@ builds:
   273981e0d5363710424b8886ac70819910a629b0:
     blobstore_id: d8fefdaf-249b-4b24-adc4-fbf0da246d66
     version: 2
-    sha1: 04bea0d9e0aeadba876a50de67488bc4db135125
+    sha1: !binary |-
+      MDRiZWEwZDllMGFlYWRiYTg3NmE1MGRlNjc0ODhiYzRkYjEzNTEyNQ==

--- a/.final_builds/jobs/ingestor_relp/index.yml
+++ b/.final_builds/jobs/ingestor_relp/index.yml
@@ -7,4 +7,5 @@ builds:
   361393b2cd51bc7762467ec6cea6e4c95f9606d9:
     blobstore_id: 2c35cefa-e59a-4fc6-97fd-07ce3b161dbd
     version: 2
-    sha1: 5090de3d35fb1c5b3171e49556b24e15f121ee87
+    sha1: !binary |-
+      NTA5MGRlM2QzNWZiMWM1YjMxNzFlNDk1NTZiMjRlMTVmMTIxZWU4Nw==

--- a/.final_builds/jobs/ingestor_syslog/index.yml
+++ b/.final_builds/jobs/ingestor_syslog/index.yml
@@ -7,4 +7,5 @@ builds:
   82e6f0f64325a9b08ddab4e281a8ab6556bc850d:
     blobstore_id: 4c66764f-0876-48ff-8642-a7c8c265cdd7
     version: 2
-    sha1: b7c8202b1c4551e1493316aa2c9bbbb74842a76c
+    sha1: !binary |-
+      YjdjODIwMmIxYzQ1NTFlMTQ5MzMxNmFhMmM5YmJiYjc0ODQyYTc2Yw==

--- a/.final_builds/jobs/log_parser/index.yml
+++ b/.final_builds/jobs/log_parser/index.yml
@@ -8,3 +8,8 @@ builds:
     blobstore_id: b649677b-855f-4ab3-92bb-3c30e9974c01
     version: 2
     sha1: 3e615a8fcded645f82f96377ba231b6eba77752a
+  !binary "YWZiODhiNzMwOWUzYTFjYWE3ZTU2MmM2NzY3ZDI4OGM3YTYzMDM0Ng==":
+    blobstore_id: 6dda141c-277a-4172-9b02-ac56e69d25e3
+    version: 3
+    sha1: !binary |-
+      NjY4Yjg3NzNjZGQyZWEyMzcxMWM2ZmQ4YWEyMDc0ZGI2MTNjMTRhNw==

--- a/.final_builds/jobs/queue/index.yml
+++ b/.final_builds/jobs/queue/index.yml
@@ -7,4 +7,5 @@ builds:
   0a2fe2f3ecbac9014d5e5d190b4f331f79761930:
     blobstore_id: d46c5c62-2832-46a2-9ae5-46c5aa43b5ca
     version: 2
-    sha1: d13e7d5e45becc1db04b97ab700c456aef72ae8a
+    sha1: !binary |-
+      ZDEzZTdkNWU0NWJlY2MxZGIwNGI5N2FiNzAwYzQ1NmFlZjcyYWU4YQ==

--- a/.final_builds/packages/collectd/index.yml
+++ b/.final_builds/packages/collectd/index.yml
@@ -3,4 +3,5 @@ builds:
   54cd62ee75b2a4d8b67062f441586260fbeee20f:
     blobstore_id: 27b98929-3746-46f7-af25-38da4f907371
     version: 1
-    sha1: 11e71da90541c290eeae6a871e382fbad3eebdb0
+    sha1: !binary |-
+      MTFlNzFkYTkwNTQxYzI5MGVlYWU2YTg3MWUzODJmYmFkM2VlYmRiMA==

--- a/.final_builds/packages/elasticsearch/index.yml
+++ b/.final_builds/packages/elasticsearch/index.yml
@@ -7,4 +7,5 @@ builds:
   01282319354bfdf955f4624a1477e10381cdb32e:
     blobstore_id: c371d732-0ca2-409e-a70c-90d5ff267b34
     version: 2
-    sha1: 1d9c26287fd045904721a7c3fc73585107bfa29d
+    sha1: !binary |-
+      MWQ5YzI2Mjg3ZmQwNDU5MDQ3MjFhN2MzZmM3MzU4NTEwN2JmYTI5ZA==

--- a/.final_builds/packages/logstash-filters-common/index.yml
+++ b/.final_builds/packages/logstash-filters-common/index.yml
@@ -1,0 +1,7 @@
+---
+builds:
+  !binary "MmJjZWEzMTA3MjY5NWIxNTYzNmYzMDZlYzZkZWIyODY1MDg3NmVkNQ==":
+    blobstore_id: 684593f1-1055-4df8-bd92-d15522040541
+    version: 1
+    sha1: !binary |-
+      ZjIyOTg1OWM3OGMzNzIwYjFmMjg4MzcyYjBlNzU0NzhlNzM4MDFmYw==

--- a/.final_builds/packages/nginx/index.yml
+++ b/.final_builds/packages/nginx/index.yml
@@ -4,3 +4,8 @@ builds:
     blobstore_id: ce09b036-ae32-4b67-9d98-878a383d14ad
     version: 1
     sha1: 61fe69d263a4d15da2e74c448359e031f9de7338
+  !binary "MGE0NzQ5NjI1MTA3NzJiMmI3ZTU5MjJjNWRjNjFlN2Q4ZTg2YzRiNg==":
+    blobstore_id: 542486d7-ed8c-40e9-abf4-4208c01ac60f
+    version: 2
+    sha1: !binary |-
+      YjIzODA0MjU4OGQyNDJlZTVjZWE2ZThmMzBiNDliZTBlN2ZjZjFkNw==

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -71,3 +71,13 @@ elasticsearch/marvel-1.1.0.zip:
   object_id: 44dbdc36-ff9d-4435-bdad-f5bc8d662854
   sha: d05f5f03493d0c49aba175bb26511d4e4c411000
   size: 1862272
+logstash-filters-common/logstash-filters-common-1.tgz:
+  object_id: e8c4e961-c914-4f3e-ab02-cc2f4cb31a03
+  sha: !binary |-
+    OWMyMmE2NWZkZWUxNmIzMzE0OGYyYjYxOGQ4NDczNzU4NjIzOWQwMw==
+  size: 604
+nginx/nginx-1.4.7.tar.gz:
+  object_id: 8fe26543-029c-45ed-a682-6c96c523dcec
+  sha: !binary |-
+    ZTEzYjViMjNmOWJlOTA4YjY5NjUyYjBjMzk0YTk1ZTkwMjk2ODdlMw==
+  size: 769153

--- a/examples/bosh-lite-with-extra-logstash-filters.yml
+++ b/examples/bosh-lite-with-extra-logstash-filters.yml
@@ -15,6 +15,7 @@ compilation:
   cloud_properties: {}
 
 update:
+  serial: false #Deploy jobs in parallel
   canaries: 1
   canary_watch_time: 30000
   update_watch_time: 30000

--- a/examples/bosh-lite-with-extra-logstash-filters.yml
+++ b/examples/bosh-lite-with-extra-logstash-filters.yml
@@ -1,0 +1,309 @@
+---
+name: logsearch
+director_uuid: f0588560-08a8-4ae2-914a-b9e8b12d9303 
+
+releases:
+- name: logsearch
+  version: latest
+- name: logsearch-cf_parsers
+  version: latest
+
+compilation:
+  workers: 3
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties: {}
+
+update:
+  canaries: 1
+  canary_watch_time: 30000
+  update_watch_time: 30000
+  max_in_flight: 4
+  max_errors: 1
+
+resource_pools:
+- name: warden
+  network: default
+  size: 6
+  stemcell:
+    name: bosh-warden-boshlite-ubuntu
+    version: latest
+  cloud_properties: {}
+
+jobs:
+- name: api
+  release: logsearch
+  templates: 
+  - name: api
+  - name: collectd
+  - name: elasticsearch
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    static_ips:
+    - 10.244.2.2
+  properties:
+    elasticsearch:
+      node:
+        allow_data: false
+
+- name: ingestor
+  release: logsearch
+  templates:
+  - name: collectd
+  - name: ingestor_lumberjack
+  - name: ingestor_syslog
+  - name: ingestor_relp
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    static_ips:
+    - 10.244.2.14
+
+- name: queue
+  release: logsearch
+  templates:
+  - name: collectd
+  - name: queue
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    static_ips:
+    - 10.244.2.10
+
+- name: log_parser
+  release: logsearch
+  templates:
+  - name: collectd
+  - name: log_parser
+  - name: logstash-filters-cf
+    release: logsearch-cf_parsers
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    default:
+    - dns
+    - gateway
+
+- name: elasticsearch_persistent
+  release: logsearch
+  templates:
+  - name: collectd
+  - name: elasticsearch
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    static_ips:
+    - 10.244.2.6
+  persistent_disk: 1024
+  properties:
+    elasticsearch:
+      node:
+        allow_master: false
+
+- name: elasticsearch_autoscale
+  release: logsearch
+  templates:
+  - name: collectd
+  - name: elasticsearch
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    default:
+    - dns
+    - gateway
+  properties:
+    elasticsearch:
+      node:
+        allow_master: false
+
+properties: 
+  collectd:
+    hostname_prefix: "dev.logsearch.repo-test1."
+    python_librato:
+      include_regex: "collectd\\.cpu\\..*,collectd\\.df\\..*,collectd\\.disk\\..*,collectd\\.elasticsearch\\..*,collectd\\.entropy\\..*,collectd\\.interface\\..*,collectd\\.load\\..*,collectd\\.memory\\..*,collectd\\.processes\\..*,collectd\\.redis_.*,collectd\\.users\\..*"
+  elasticsearch:
+    cluster_name: logsearch
+    discovery:
+      ping_unicast_hosts: "10.244.2.2,10.244.2.6" # Seem to have to list all master nodes?
+    indices:
+      ttl_interval: "60s"  # We want documents from test runs to be cleaned up frequently
+  logstash:
+    debug: true
+    queue:
+      redis:
+        host: 10.244.2.10
+    output:
+      elasticsearch:
+        host: 10.244.2.2
+    input:
+      relp:
+        debug: true
+        port: 5514
+      syslog:
+        debug: true
+      lumberjack:
+        debug: true
+        ssl_certificate: |
+            -----BEGIN CERTIFICATE-----
+            MIIDtTCCAp2gAwIBAgIJALfb51kZrob4MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+            BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
+            aWRnaXRzIFB0eSBMdGQwHhcNMTQwMTMxMDcxODE3WhcNMTQwMzAyMDcxODE3WjBF
+            MQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50
+            ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+            CgKCAQEAvxWkAQk9NtV7DIbqFubSBPw7twd0DvYDaQAErokTVWHYGHhIFAxW0+Tl
+            1nAVLVUUJK92ARW+sLJ81A30DMuyAeA7tVBZW4TYD+XPleame081rcGbC0rOEbej
+            yEm7ZlqnTmZb8twG8fRjQ0DkworMLNWRCNWLFGb9P07b/eY3+hux8xsQOyRogtHJ
+            xLjpqQROYrSJ+Ldzgs8TSJ6NkieeBCMx+KrYGqohej3DeD4qHeqWTF8ieFs6+JT4
+            1ZEdv4MbLNXoXnxihsXPRKaUps1tXPw43c2mDIXsacxjWB2UyzPZ7+DPdzb0becr
+            9xHVCkO6BCz93bK/8HTuAwW7qJn50wIDAQABo4GnMIGkMB0GA1UdDgQWBBTN+5+G
+            CCwjJx1qlS686oxo/qcigjB1BgNVHSMEbjBsgBTN+5+GCCwjJx1qlS686oxo/qci
+            gqFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNV
+            BAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJALfb51kZrob4MAwGA1UdEwQF
+            MAMBAf8wDQYJKoZIhvcNAQEFBQADggEBACEfgFDGd+JbKrDPbnH6blJuprCFPwZQ
+            JDprPAXscFSbvtKPMLOjkoJ+v+X3MIYIsmeVEXoYXwGE/QAUXYTddJXW4BQYQMi9
+            tI7qscOjN9532oiNCvDEt1ERReYfTQAXby2PP9rPMAXZAB6GdqlztFfks8tzjJ8C
+            ZkUQUGQKHTQXk7rGkrutwuPFrhhEmE2+BGPQcNTZrFswZbx3bkfznOPMDMCTCDN0
+            H/ir11J9xS1XazdyHBWTNQU5dBbmyrd0FmcCZI+dLO+iuLox7JyviVqj+ic+SeRR
+            23UffFuq8sIwkc6t+a4RuPd8uF4g0sVmdiDaa4rZp0wIO4Q0QM62kV8=
+            -----END CERTIFICATE-----
+        ssl_key: |
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEpQIBAAKCAQEAvxWkAQk9NtV7DIbqFubSBPw7twd0DvYDaQAErokTVWHYGHhI
+            FAxW0+Tl1nAVLVUUJK92ARW+sLJ81A30DMuyAeA7tVBZW4TYD+XPleame081rcGb
+            C0rOEbejyEm7ZlqnTmZb8twG8fRjQ0DkworMLNWRCNWLFGb9P07b/eY3+hux8xsQ
+            OyRogtHJxLjpqQROYrSJ+Ldzgs8TSJ6NkieeBCMx+KrYGqohej3DeD4qHeqWTF8i
+            eFs6+JT41ZEdv4MbLNXoXnxihsXPRKaUps1tXPw43c2mDIXsacxjWB2UyzPZ7+DP
+            dzb0becr9xHVCkO6BCz93bK/8HTuAwW7qJn50wIDAQABAoIBAQCeG7bnUJDBFWVK
+            WTvKlVTD4T071cP3OSJbODOngy5nIJ2gqa3iQM97ZtOyWm17ZAFV1YULosV1CUr2
+            X1FHYSg6GyLshL5bVpE8nkfkXcP1FfZxflfewRe/Wzb+29te9rWmzlVYnyxz+WZE
+            2KYwPo5wroniSGdbC1iSkJrA/EPnAp/eOchwmy3RAdE/6unFOBugNjn4fIi0fXEz
+            r+jD+bDW7jhkdEvAZDil4uzKLE8ICquoYwmEQ6WWoosTVszCTT9RtoL/NT3EZMPf
+            VWcjDYh9OjVUKTkOUAKERE83yP0l37Eum2yc0vGE6it0HdlM6FTqJBw7LBUC8Lub
+            BXGIUHqRAoGBAP52RwSP0+GHF3UZJ+6II3fEtZ9s1IWfjxcNj6myUjXNfq5woOWy
+            LD9Qqx6Qs5XqpnfxI3ZeaUwzwpkSupaUrkMlzJsvk6zMp45hldfr/ht4Vj6KeEWx
+            r5j+PLI4L9CYJb15E5bAvhvVwQXeroS4uXwQozyJses95wVnSteRf+NrAoGBAMA9
+            TQUl1nduirDjsASCGw6iQTTGQNJ+Anf/b/zEpzzTUvt+4IeOkN2w8k9Wd73XdJzv
+            /qLifh2btPWkAG9XKR0W84Z/CSDdYEO1qJPwZMCn65Dguy0/pQC0PE8kX/hLj+I0
+            8ToNZmZgrhIzNyI17xcx/GofVxXg93ccFhPCHcU5AoGBAO0tF2K0IHx8ayvVB7g4
+            Ij73FYaEbM4je760ACzerevCHwq+pemSmdVl/ileHFVmwkTXeQNSWnkRYZdFsq65
+            5Hdn2v7maJHOq3p1kLISH+ZA0ro2XIYxaQeEKNTAtCiMN9kT6mNAQbI2GVS8SxQg
+            DZsK8utxOGmYaCVMMqEc2AQDAoGALEuzvJTsZxaslHfSbieAjo2qkrt/4kCw1u+f
+            4VF665QSEes5V2LtVHfaTZex/adwslzGgsfHoZDoUJWamA0wZwiL0pjhBJaeANwR
+            3QzOWmoW6Iov9wwsPA5Luzy5dGAM5mWmk+bUipCKa50rfhGJZwHYlKdmDJ+KxgJN
+            v/3BmFkCgYEA3EjcbIpTO7/sLYT1Cz71nYriwYpndAnVmleoVLcapf2PRHaH1qg9
+            TZ4pxCBbr20WJhV4AfIkP1H2ng/vZVTTkGalGfzAaDy68iHx3lzVTB2jGgPh0io5
+            eQSIQMkokjB6eyo3P26r0Tnd/Z8fFko86k51mB3nWvVwGt9xvKWGjhU=
+            -----END RSA PRIVATE KEY-----
+
+# Warden CPI requires crappy network settings; so "hide" them away here
+networks:
+- name: default
+  # Assumes up to 7 VMs, including 4 static and 3 dynamic.
+  # Plus 7 (double the size) unused IPs, due to BOSH bug/quirk.
+  subnets:
+  - cloud_properties:
+      name: random
+    range: 10.244.2.0/30
+    reserved:
+    - 10.244.2.1
+    static:
+    - 10.244.2.2
+  - cloud_properties:
+      name: random
+    range: 10.244.2.4/30
+    reserved:
+    - 10.244.2.5
+    static:
+    - 10.244.2.6
+  - cloud_properties:
+      name: random
+    range: 10.244.2.8/30
+    reserved:
+    - 10.244.2.9
+    static: 
+    - 10.244.2.10
+  - cloud_properties:
+      name: random
+    range: 10.244.2.12/30
+    reserved:
+    - 10.244.2.13
+    static: 
+    - 10.244.2.14
+
+  - cloud_properties:
+      name: random
+    range: 10.244.2.16/30
+    reserved:
+    - 10.244.2.17
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.20/30
+    reserved:
+    - 10.244.2.21
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.24/30
+    reserved:
+    - 10.244.2.25
+    static: []
+
+  # Bonus double-sized network required due to BOSH oddity
+  - cloud_properties:
+      name: random
+    range: 10.244.2.28/30
+    reserved:
+    - 10.244.2.29
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.32/30
+    reserved:
+    - 10.244.2.33
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.36/30
+    reserved:
+    - 10.244.2.37
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.40/30
+    reserved:
+    - 10.244.2.41
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.44/30
+    reserved:
+    - 10.244.2.45
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.48/30
+    reserved:
+    - 10.244.2.49
+    static: []
+  - cloud_properties:
+      name: random
+    range: 10.244.2.52/30
+    reserved:
+    - 10.244.2.53
+    static: []
+
+apply_spec:
+  properties:
+    ntp:
+      - 0.europe.pool.ntp.org
+      - 1.europe.pool.ntp.org
+      - 2.europe.pool.ntp.org
+      - 3.europe.pool.ntp.org

--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -13,6 +13,7 @@ compilation:
   cloud_properties: {}
 
 update:
+  serial: false #Deploy jobs in parallel
   canaries: 1
   canary_watch_time: 30000
   update_watch_time: 30000

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -2,6 +2,7 @@
 name: log_parser
 packages: 
   - logstash
+  - logstash-filters-common
   - java7
 templates:
   bin/log_parser_ctl: bin/log_parser_ctl

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -10,8 +10,9 @@ templates:
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
-  config/redis_to_elasticsearch.conf.erb: config/redis_to_elasticsearch.conf
-
+  config/input_redis_and_output_elasticsearch.conf.erb: config/input_redis_and_output_elasticsearch.conf
+  config/filters_pre.conf.erb: config/filters_pre.conf
+  config/filters_post.conf.erb: config/filters_post.conf
 properties:
   logstash.debug:
     description: Debug level logging

--- a/jobs/log_parser/templates/bin/log_parser_ctl
+++ b/jobs/log_parser/templates/bin/log_parser_ctl
@@ -19,8 +19,14 @@ case $1 in
     # store this processes pid in $PIDFILE, since the exec below doesn't daemonize
     echo $$ > $PIDFILE
 
+    # construct a complete config file from all the fragments
+    cat ${JOB_DIR}/config/input_redis_and_output_elasticsearch.conf > ${JOB_DIR}/config/all_inputs_outputs_filters.conf 
+    cat ${JOB_DIR}/config/filters_pre.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf 
+    cat /var/vcap/packages/logstash-filters-*/*.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf
+    cat ${JOB_DIR}/config/filters_post.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf 
+
     exec /var/vcap/packages/java7/bin/java -jar /var/vcap/packages/logstash/logstash.jar agent \
-         -f ${JOB_DIR}/config/redis_to_elasticsearch.conf -w ${LOGSTASH_WORKERS} \
+         -f ${JOB_DIR}/config/all_inputs_outputs_filters.conf -w ${LOGSTASH_WORKERS} \
          >>$LOG_DIR/$JOB_NAME.stdout.log \
          2>>$LOG_DIR/$JOB_NAME.stderr.log
 

--- a/jobs/log_parser/templates/config/filters_post.conf.erb
+++ b/jobs/log_parser/templates/config/filters_post.conf.erb
@@ -1,0 +1,12 @@
+
+    #
+    # type-casting for more advanced searches
+    #
+
+    if "nginx" in [tags] {
+        mutate {
+            convert => [ "status", "integer" ]
+            convert => [ "body_bytes_sent", "integer" ]
+        }
+    }
+}

--- a/jobs/log_parser/templates/config/filters_pre.conf.erb
+++ b/jobs/log_parser/templates/config/filters_pre.conf.erb
@@ -1,15 +1,3 @@
-input {
-
-    redis {
-        host => "<%= p("logstash.queue.redis.host") %>"
-        port => "<%= p("logstash.queue.redis.port") %>"
-        type => "redis-input"
-        data_type => "list"
-        key => "<%= p("logstash.queue.redis.key") %>"
-        threads => 8
-    }
-}
-
 filter {
 
     #
@@ -90,35 +78,3 @@ filter {
     # Additional filter types from /var/vcap/packages/logstash-filters-*/*.conf
     #
 
-    <% Dir.glob("/var/vcap/packages/logstash-filters-*/*.conf") do |filter_erb_file| %>
-      <%= ERB.new(File.read(filter_erb_file), nil, nil, '_filter_sub_template').result(binding) %>
-    <% end %>
-
-    #
-    # type-casting for more advanced searches
-    #
-
-    if "nginx" in [tags] {
-        mutate {
-            convert => [ "status", "integer" ]
-            convert => [ "body_bytes_sent", "integer" ]
-        }
-    }
-}
-
-output {
-    <% if_p("logstash.debug") do %>
-    stdout { debug => true codec => "json"}
-    <% end %>
-
-    elasticsearch_http {
-        host => "<%= p("logstash.output.elasticsearch.host") %>:<%= p("logstash.output.elasticsearch.port") %>"
-        flush_size => <%= p("logstash.output.elasticsearch.flush_size") %>
-        index_type => "%{@type}"
-        manage_template => false
-    }
-}
-
-
-
-    

--- a/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
@@ -1,0 +1,25 @@
+input {
+
+    redis {
+        host => "<%= p("logstash.queue.redis.host") %>"
+        port => "<%= p("logstash.queue.redis.port") %>"
+        type => "redis-input"
+        data_type => "list"
+        key => "<%= p("logstash.queue.redis.key") %>"
+        threads => 8
+    }
+}
+
+output {
+    <% if_p("logstash.debug") do %>
+    stdout { debug => true codec => "json"}
+    <% end %>
+
+    elasticsearch_http {
+        host => "<%= p("logstash.output.elasticsearch.host") %>:<%= p("logstash.output.elasticsearch.port") %>"
+        flush_size => <%= p("logstash.output.elasticsearch.flush_size") %>
+        index_type => "%{@type}"
+        manage_template => false
+    }
+}
+    

--- a/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
@@ -1,23 +1,23 @@
 input {
 
     redis {
-        host => "<%= p("logstash.queue.redis.host") %>"
-        port => "<%= p("logstash.queue.redis.port") %>"
+        host => "<%= p("redis.host") %>"
+        port => "<%= p("redis.port") %>"
         type => "redis-input"
         data_type => "list"
-        key => "<%= p("logstash.queue.redis.key") %>"
+        key => "<%= p("redis.key") %>"
         threads => 8
     }
 }
 
 output {
-    <% if_p("logstash.debug") do %>
+    <% if_p("logstash_parser.debug") do %>
     stdout { debug => true codec => "json"}
     <% end %>
 
     elasticsearch_http {
-        host => "<%= p("logstash.output.elasticsearch.host") %>:<%= p("logstash.output.elasticsearch.port") %>"
-        flush_size => <%= p("logstash.output.elasticsearch.flush_size") %>
+        host => "<%= p("elasticsearch.host") %>:<%= p("elasticsearch.port") %>"
+        flush_size => <%= p("elasticsearch.flush_size") %>
         index_type => "%{@type}"
         manage_template => false
     }

--- a/jobs/log_parser/templates/config/redis_to_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/redis_to_elasticsearch.conf.erb
@@ -11,6 +11,17 @@ input {
 }
 
 filter {
+
+    #
+    # Default type to _logstash_input 
+    #
+
+    alter {
+        coalesce => [
+            "type", "%{_logstash_input}", "%{_type}"
+        ]
+    }
+
     #
     # rewrite our defined globals
     #

--- a/jobs/log_parser/templates/config/redis_to_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/redis_to_elasticsearch.conf.erb
@@ -75,10 +75,13 @@ filter {
         }
     }
 
-    #TODO - Pull in other filter types
-    <%# Dir.glob("#{ENV['APP_APP_DIR']}/srv/logstash/config/filter.d/*.conf.erb") do |filter_erb_file| %>
-      <%#= ERB.new(File.read(filter_erb_file), nil, nil, '_filter_sub_template').result(binding) %>
-    <%# end %>
+    #
+    # Additional filter types from /var/vcap/packages/logstash-filters-*/*.conf
+    #
+
+    <% Dir.glob("/var/vcap/packages/logstash-filters-*/*.conf") do |filter_erb_file| %>
+      <%= ERB.new(File.read(filter_erb_file), nil, nil, '_filter_sub_template').result(binding) %>
+    <% end %>
 
     #
     # type-casting for more advanced searches

--- a/packages/logstash-filters-common/packaging
+++ b/packages/logstash-filters-common/packaging
@@ -1,0 +1,12 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+FILTERS_TGZ=logstash-filters-common/logstash-filters-common-*.tgz
+
+tar xvzf $FILTERS_TGZ && rm $FILTERS_TGZ
+
+cp -R *.conf $BOSH_INSTALL_TARGET

--- a/packages/logstash-filters-common/spec
+++ b/packages/logstash-filters-common/spec
@@ -1,0 +1,5 @@
+---
+name: logstash-filters-common
+dependencies: []
+files:
+  - logstash-filters-common/logstash-filters-common-1.tgz

--- a/packages/nginx/packaging
+++ b/packages/nginx/packaging
@@ -11,8 +11,8 @@ echo "Extracting pcre..."
 tar xzvf nginx/pcre-8.33.tar.gz
 
 echo "Extracting nginx..."
-tar xfv nginx/nginx-1.4.2.tar.gz
-cd nginx-1.4.2
+tar xfv nginx/nginx-1.4.7.tar.gz
+cd nginx-1.4.7
 ./configure \
   --prefix=${BOSH_INSTALL_TARGET} \
   --with-pcre=../pcre-8.33 \

--- a/packages/nginx/spec
+++ b/packages/nginx/spec
@@ -2,5 +2,5 @@
 name: nginx
 dependencies: []
 files:
-- nginx/nginx-1.4.2.tar.gz
+- nginx/nginx-1.4.7.tar.gz
 - nginx/pcre-8.33.tar.gz

--- a/releases/index.yml
+++ b/releases/index.yml
@@ -6,3 +6,5 @@ builds:
     version: 2
   1695c2b52cffc5ebef1df48d89e333c4d633fa9c:
     version: 3
+  !binary "NzI0MDc0M2IyYTQ1NDc5Y2U3ZDQ3NGU1ZTM3YzllYWM2ZDJjZjdkNQ==":
+    version: 4

--- a/releases/logsearch-4.yml
+++ b/releases/logsearch-4.yml
@@ -1,0 +1,104 @@
+---
+packages:
+- name: collectd
+  version: 1
+  sha1: !binary |-
+    MTFlNzFkYTkwNTQxYzI5MGVlYWU2YTg3MWUzODJmYmFkM2VlYmRiMA==
+  fingerprint: !binary |-
+    NTRjZDYyZWU3NWIyYTRkOGI2NzA2MmY0NDE1ODYyNjBmYmVlZTIwZg==
+  dependencies: []
+- name: elasticsearch
+  version: 2
+  sha1: !binary |-
+    MWQ5YzI2Mjg3ZmQwNDU5MDQ3MjFhN2MzZmM3MzU4NTEwN2JmYTI5ZA==
+  fingerprint: !binary |-
+    MDEyODIzMTkzNTRiZmRmOTU1ZjQ2MjRhMTQ3N2UxMDM4MWNkYjMyZQ==
+  dependencies: []
+- name: java7
+  version: 1
+  sha1: !binary |-
+    YThhYjhkM2MwZGY2YjNlMzI1NGYwY2FlOTYwNmUxZTc3MzJjNDBkYw==
+  fingerprint: !binary |-
+    ZmJhZGU2OTg4MTYwYmQ4NTc2ZDRjMWM0NGEwZWIwNDlkNzAwODU4Zg==
+  dependencies: []
+- name: logstash
+  version: 1
+  sha1: !binary |-
+    MzE1NzBlNGY2YzQwNzk1ZjY2YmFkMTY0NGQ4Mjc2OWExZDg4NzdiZQ==
+  fingerprint: !binary |-
+    YjRjYTVlNzliMDQ0MWI4ODQ3ZjgyMzg1NjhlY2Y4MTFiODRhMjkwYg==
+  dependencies: []
+- name: logstash-filters-common
+  version: 1
+  sha1: !binary |-
+    ZjIyOTg1OWM3OGMzNzIwYjFmMjg4MzcyYjBlNzU0NzhlNzM4MDFmYw==
+  fingerprint: !binary |-
+    MmJjZWEzMTA3MjY5NWIxNTYzNmYzMDZlYzZkZWIyODY1MDg3NmVkNQ==
+  dependencies: []
+- name: nginx
+  version: 2
+  sha1: !binary |-
+    YjIzODA0MjU4OGQyNDJlZTVjZWE2ZThmMzBiNDliZTBlN2ZjZjFkNw==
+  fingerprint: !binary |-
+    MGE0NzQ5NjI1MTA3NzJiMmI3ZTU5MjJjNWRjNjFlN2Q4ZTg2YzRiNg==
+  dependencies: []
+- name: redis
+  version: 1
+  sha1: !binary |-
+    OWFmOWY2MTNmZGRjY2YxNThkYjNkZmE2M2FmOGIxYjFjYTJiMzBmNw==
+  fingerprint: !binary |-
+    ZTJhNGVjNzE4MzY1ZmQ4ZmYyYTJkZjFlZmJiMTNlNmY4MmY5NDg1NQ==
+  dependencies: []
+jobs:
+- name: api
+  version: 2
+  fingerprint: !binary |-
+    Y2ZhZmVjYjI1Y2FjNjk0ZWYzNjQ2MGM3Yjg3ODVhYmU3ZmYwNmYwYQ==
+  sha1: !binary |-
+    ZjM0MDljZjYyMjk3ODdkMDQ5MjRhNmMwNjMyMWRkZjEwY2RlMzA0ZQ==
+- name: collectd
+  version: 1
+  fingerprint: !binary |-
+    ZWM1N2RkMmFkMDE5OWM5ODlkYzE3YzM3NzcxODdlODhjNTFmMjQ2NA==
+  sha1: !binary |-
+    NGVmMzM2YzYzMDE1OTkxZTMxZDAzYmRlZjM4MGRiMGU1MmM2OTFjYQ==
+- name: elasticsearch
+  version: 2
+  fingerprint: !binary |-
+    YWFiNjRlNWNkZDI1NmZlMWVlZmZkZmU0ZDcwNzNlZmI1NGExODc2Ng==
+  sha1: !binary |-
+    Zjg1MDYwNDA1YTBkN2Q0YzBiY2RjNDYzZGQwZDg4ODIxNmFhMGI0ZQ==
+- name: ingestor_lumberjack
+  version: 2
+  fingerprint: !binary |-
+    MjczOTgxZTBkNTM2MzcxMDQyNGI4ODg2YWM3MDgxOTkxMGE2MjliMA==
+  sha1: !binary |-
+    MDRiZWEwZDllMGFlYWRiYTg3NmE1MGRlNjc0ODhiYzRkYjEzNTEyNQ==
+- name: ingestor_relp
+  version: 2
+  fingerprint: !binary |-
+    MzYxMzkzYjJjZDUxYmM3NzYyNDY3ZWM2Y2VhNmU0Yzk1Zjk2MDZkOQ==
+  sha1: !binary |-
+    NTA5MGRlM2QzNWZiMWM1YjMxNzFlNDk1NTZiMjRlMTVmMTIxZWU4Nw==
+- name: ingestor_syslog
+  version: 2
+  fingerprint: !binary |-
+    ODJlNmYwZjY0MzI1YTliMDhkZGFiNGUyODFhOGFiNjU1NmJjODUwZA==
+  sha1: !binary |-
+    YjdjODIwMmIxYzQ1NTFlMTQ5MzMxNmFhMmM5YmJiYjc0ODQyYTc2Yw==
+- name: log_parser
+  version: 3
+  fingerprint: !binary |-
+    YWZiODhiNzMwOWUzYTFjYWE3ZTU2MmM2NzY3ZDI4OGM3YTYzMDM0Ng==
+  sha1: !binary |-
+    NjY4Yjg3NzNjZGQyZWEyMzcxMWM2ZmQ4YWEyMDc0ZGI2MTNjMTRhNw==
+- name: queue
+  version: 2
+  fingerprint: !binary |-
+    MGEyZmUyZjNlY2JhYzkwMTRkNWU1ZDE5MGI0ZjMzMWY3OTc2MTkzMA==
+  sha1: !binary |-
+    ZDEzZTdkNWU0NWJlY2MxZGIwNGI5N2FiNzAwYzQ1NmFlZjcyYWU4YQ==
+commit_hash: 3de35cd6
+uncommitted_changes: true
+name: logsearch
+version: 4

--- a/scripts/assign_all_unassigned_shards.sh
+++ b/scripts/assign_all_unassigned_shards.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+ES_URI=${ES_URI:?"env ES_URI must be set"}
+ASSIGN_TO_NODE=${ASSIGN_TO_NODE:?"env ASSIGN_TO_NODE must be set"}
+
+function reroute() {
+    curl -XPOST "${ES_URI}/_cluster/reroute?pretty" -d '{
+        "commands" : [ {
+                "allocate" : {
+                    "index" : "'$1'",
+                    "shard" : '$2'
+                    "node" : "'${ASSIGN_TO_NODE}'"
+                }
+            }
+        ]
+    }' > /dev/null
+    sleep 100
+}
+curl -s ${ES_URI}/_cluster/state?pretty | awk '
+    BEGIN {more=1}
+    {if (/"UNASSIGNED"/) unassigned=1}
+    {if (/"routing_nodes"/) more=0}
+    {if (unassigned && /"shard"/) shard=$3}
+    {if (more && unassigned && /"index"/) {print "reroute",$3, shard; unassigned=false}}
+' > runit
+source runit


### PR DESCRIPTION
This is an BOSH implementation showing how to integrate [additional logstash-filters](http://labs.cityindex.com/labs-team/2014/03/27/rfc-logstash-filter-repositories/) into an existing `logstash-boshrelease`

In summary, you extend your logsearch deployment manifest like this:

``` yaml
releases:
  - name: logsearch
    version: latest
  - name: logstash-filters-cf
    version: latest

...

jobs:
- name: log_parser
  release: logsearch
  templates: 
  - name: log_parser
  - name: logstash-filters-cf
    release: logstash-filters-cf
```

The `logstash-filters-cf` job places additional logstash filters in `/var/vcap/packages/logstash-filters-cf/logstash-filters-cf.conf`

On installation, the `log_parser` job includes all additional filters from `/var/vcap/packages/logstash-filters-*/logstash-filters-*.conf`
