### PR TITLE
Add logstash-forwarder

### DIFF
--- a/.final_builds/jobs/api/index.yml
+++ b/.final_builds/jobs/api/index.yml
@@ -7,5 +7,8 @@ builds:
   cfafecb25cac694ef36460c7b8785abe7ff06f0a:
     blobstore_id: f21dfcc9-53ae-4827-ac8f-ba668193a24a
     version: 2
-    sha1: !binary |-
-      ZjM0MDljZjYyMjk3ODdkMDQ5MjRhNmMwNjMyMWRkZjEwY2RlMzA0ZQ==
+    sha1: f3409cf6229787d04924a6c06321ddf10cde304e
+  858302bf14826a83697bb70a27200d5092263806:
+    blobstore_id: bad8d0b5-c479-4763-84b9-f312b99bfd68
+    version: 3
+    sha1: c32c2af121f05f7eff03bfa252c16db3568d4a76

--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -49,6 +49,14 @@ jobs:
     elasticsearch:
       node:
         allow_data: false
+    logstash_forwarder:
+      files:
+      - path: /var/vcap/sys/log/elasticsearch/requests.log
+        type: elasticsearch_request
+      - path: /var/vcap/sys/log/api/nginx.access.log
+        type: nginx_access
+      - path: /var/vcap/sys/log/api/nginx.error.log
+        type: nginx_error
 
 - name: ingestor
   release: logsearch
@@ -140,7 +148,7 @@ properties:
       include_regex: "collectd\\.cpu\\..*,collectd\\.df\\..*,collectd\\.disk\\..*,collectd\\.elasticsearch\\..*,collectd\\.entropy\\..*,collectd\\.interface\\..*,collectd\\.load\\..*,collectd\\.memory\\..*,collectd\\.processes\\..*,collectd\\.redis_.*,collectd\\.users\\..*"
   elasticsearch:
     host: 10.244.2.2
-    cluster_name: logsearch
+    cluster_name: logsearch--bosh-lite
     indices:
       ttl_interval: "5m"  # We want documents from test runs to be cleaned up frequently
   redis:

--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -50,7 +50,7 @@ jobs:
       node:
         allow_data: false
     logstash_forwarder:
-      files:
+      job_files:
       - path: /var/vcap/sys/log/elasticsearch/requests.log
         type: elasticsearch_request
       - path: /var/vcap/sys/log/api/nginx.access.log

--- a/jobs/elasticsearch/templates/config/logging.yml.erb
+++ b/jobs/elasticsearch/templates/config/logging.yml.erb
@@ -20,7 +20,7 @@ appender:
 
   request_log_file:
     type: dailyRollingFile
-    file: ${path.logs}/${cluster.name}_requests.log
+    file: ${path.logs}/requests.log
     datePattern: "'.'yyyy-MM-dd"
     layout:
       type: pattern

--- a/jobs/logstash_forwarder/monit
+++ b/jobs/logstash_forwarder/monit
@@ -1,0 +1,5 @@
+check process logstash_forwarder
+  with pidfile /var/vcap/sys/run/logstash_forwarder/logstash_forwarder.pid
+  start program "/var/vcap/jobs/logstash_forwarder/bin/monit_debugger logstash_forwarder_ctl '/var/vcap/jobs/logstash_forwarder/bin/logstash_forwarder_ctl start'"
+  stop program "/var/vcap/jobs/logstash_forwarder/bin/monit_debugger logstash_forwarder_ctl '/var/vcap/jobs/logstash_forwarder/bin/logstash_forwarder_ctl stop'"
+  group vcap

--- a/jobs/logstash_forwarder/spec
+++ b/jobs/logstash_forwarder/spec
@@ -18,13 +18,15 @@ properties:
   logstash_forwarder.port:
     default: 5043
     description: "The lumberjack endpoint port."
-  logstash_forwarder.ssl_crt:
+  logstash_forwarder.ssl_certificate:
     default: ''
     description: "The contents of your client ssl certificate (optional)."
   logstash_forwarder.ssl_key:
     default: ''
     description: "The contents to your client ssl key (optional)."
-  logstash_forwarder.ssl_ca_crt:
+  logstash_forwarder.ssl_ca_certificate:
     description: "The path to your trusted ssl CA file. This is used to authenticate your downstream server."
-  logstash_forwarder.files:
-    description: "Log files for forwarding (path should be the key, and the sub-object with a `type` key-value should be specified)."
+  logstash_forwarder.job_files:
+    description: "Log files for forwarding (job-specific; path should be the key, and the sub-object with a `type` key-value should be specified)."
+  logstash_forwarder.global_files:
+    description: "Log files for forwarding (shared across all jobs; path should be the key, and the sub-object with a `type` key-value should be specified)."

--- a/jobs/logstash_forwarder/spec
+++ b/jobs/logstash_forwarder/spec
@@ -26,3 +26,5 @@ properties:
     description: "The contents to your client ssl key (optional)."
   logstash_forwarder.ssl_ca_crt:
     description: "The path to your trusted ssl CA file. This is used to authenticate your downstream server."
+  logstash_forwarder.files:
+    description: "Log files for forwarding (path should be the key, and the sub-object with a `type` key-value should be specified)."

--- a/jobs/logstash_forwarder/spec
+++ b/jobs/logstash_forwarder/spec
@@ -1,0 +1,28 @@
+---
+name: logstash_forwarder
+packages:
+  - logstash-forwarder
+templates:
+  bin/logstash_forwarder_ctl: bin/logstash_forwarder_ctl
+  bin/monit_debugger: bin/monit_debugger
+  data/properties.sh.erb: data/properties.sh
+  config/config.json.erb: config/config.json
+  config/ssl-ca.crt.erb: config/ssl-ca.crt
+  config/ssl.crt.erb: config/ssl.crt
+  config/ssl.key.erb: config/ssl.key
+  helpers/ctl_setup.sh: helpers/ctl_setup.sh
+  helpers/ctl_utils.sh: helpers/ctl_utils.sh
+properties:
+  logstash_forwarder.servers:
+    description: "The lumberjack endpoints (array with values {host:port})."
+  logstash_forwarder.port:
+    default: 5043
+    description: "The lumberjack endpoint port."
+  logstash_forwarder.ssl_crt:
+    default: ''
+    description: "The contents of your client ssl certificate (optional)."
+  logstash_forwarder.ssl_key:
+    default: ''
+    description: "The contents to your client ssl key (optional)."
+  logstash_forwarder.ssl_ca_crt:
+    description: "The path to your trusted ssl CA file. This is used to authenticate your downstream server."

--- a/jobs/logstash_forwarder/templates/bin/logstash_forwarder_ctl
+++ b/jobs/logstash_forwarder/templates/bin/logstash_forwarder_ctl
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/logstash_forwarder/helpers/ctl_setup.sh 'logstash_forwarder'
+
+export PORT=${PORT:-5000}
+export LANG=en_US.UTF-8
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+
+    echo $$ > $PIDFILE
+
+    # it maintains the .logstash-forwarder with file offsets in $PWD
+    cd /var/vcap/store/logstash_forwarder
+
+    exec chpst -u vcap:vcap /var/vcap/packages/logstash-forwarder/logstash-forwarder -config "$JOB_DIR/config/config.json" \
+         >>$LOG_DIR/$JOB_NAME.stdout.log \
+         2>>$LOG_DIR/$JOB_NAME.stderr.log
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: logstash_forwarder_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/logstash_forwarder/templates/bin/monit_debugger
+++ b/jobs/logstash_forwarder/templates/bin/monit_debugger
@@ -1,0 +1,13 @@
+#!/bin/sh
+# USAGE monit_debugger <label> command to run
+mkdir -p /var/vcap/sys/log/monit
+{
+  echo "MONIT-DEBUG date"
+  date
+  echo "MONIT-DEBUG env"
+  env
+  echo "MONIT-DEBUG $@"
+  $2 $3 $4 $5 $6 $7
+  R=$?
+  echo "MONIT-DEBUG exit code $R"
+} >/var/vcap/sys/log/monit/monit_debugger.$1.log 2>&1

--- a/jobs/logstash_forwarder/templates/config/config.json.erb
+++ b/jobs/logstash_forwarder/templates/config/config.json.erb
@@ -1,0 +1,39 @@
+{
+  "network": {
+    "servers": [<% p('logstash_forwarder.servers').each_with_index do | v, i | %><% if 0 < i %>,<% end %>"<%= v %>"<% end %>],
+    <% if '' != p('logstash_forwarder.ssl_crt') %>
+      "ssl certificate": "/var/vcap/jobs/logstash_forwarder/config/ssl.crt",
+    <% end %>
+    <% if '' != p('logstash_forwarder.ssl_key') %>
+      "ssl key": "/var/vcap/jobs/logstash_forwarder/config/ssl.key",
+    <% end %>
+    "ssl ca": "/var/vcap/jobs/logstash_forwarder/config/ssl-ca.crt",
+    "timeout": 15
+  },
+  "files": [
+    {
+      "paths": [
+        "/var/vcap/sys/log/elasticsearch/requests.log"
+      ],
+      "fields": {
+        "@type": "elasticsearch_request"
+      }
+    },
+    {
+      "paths": [
+        "/var/vcap/sys/log/api/nginx.access.log"
+      ],
+      "fields": {
+        "@type": "nginx_access"
+      }
+    },
+    {
+      "paths": [
+        "/var/vcap/sys/log/api/nginx.error.log"
+      ],
+      "fields": {
+        "@type": "nginx_error"
+      }
+    }
+  ]
+}

--- a/jobs/logstash_forwarder/templates/config/config.json.erb
+++ b/jobs/logstash_forwarder/templates/config/config.json.erb
@@ -1,7 +1,7 @@
 {
   "network": {
     "servers": [<% p('logstash_forwarder.servers').each_with_index do | v, i | %><% if 0 < i %>,<% end %>"<%= v %>"<% end %>],
-    <% if '' != p('logstash_forwarder.ssl_crt') %>
+    <% if '' != p('logstash_forwarder.ssl_certificate') %>
       "ssl certificate": "/var/vcap/jobs/logstash_forwarder/config/ssl.crt",
     <% end %>
     <% if '' != p('logstash_forwarder.ssl_key') %>
@@ -12,7 +12,7 @@
   },
   "files": [
     <% prefix = '' %>
-    <% p('logstash_forwarder.files').each do | file | %><%= prefix %><% prefix = ',' %>
+    <% [].push(* p('logstash_forwarder.global_files')).push(* p('logstash_forwarder.job_files')).each do | file | %><%= prefix %><% prefix = ',' %>
       {
         "paths" : [ "<%= file['path'] %>" ],
         "fields" : {

--- a/jobs/logstash_forwarder/templates/config/config.json.erb
+++ b/jobs/logstash_forwarder/templates/config/config.json.erb
@@ -11,29 +11,14 @@
     "timeout": 15
   },
   "files": [
-    {
-      "paths": [
-        "/var/vcap/sys/log/elasticsearch/requests.log"
-      ],
-      "fields": {
-        "@type": "elasticsearch_request"
+    <% prefix = '' %>
+    <% p('logstash_forwarder.files').each do | file | %><%= prefix %><% prefix = ',' %>
+      {
+        "paths" : [ "<%= file['path'] %>" ],
+        "fields" : {
+          "@type" : "<%= file['type'] %>"
+        }
       }
-    },
-    {
-      "paths": [
-        "/var/vcap/sys/log/api/nginx.access.log"
-      ],
-      "fields": {
-        "@type": "nginx_access"
-      }
-    },
-    {
-      "paths": [
-        "/var/vcap/sys/log/api/nginx.error.log"
-      ],
-      "fields": {
-        "@type": "nginx_error"
-      }
-    }
+    <% end %>
   ]
 }

--- a/jobs/logstash_forwarder/templates/config/ssl-ca.crt.erb
+++ b/jobs/logstash_forwarder/templates/config/ssl-ca.crt.erb
@@ -1,1 +1,1 @@
-<%= p('logstash_forwarder.ssl_ca_crt') %>
+<%= p('logstash_forwarder.ssl_ca_certificate') %>

--- a/jobs/logstash_forwarder/templates/config/ssl-ca.crt.erb
+++ b/jobs/logstash_forwarder/templates/config/ssl-ca.crt.erb
@@ -1,0 +1,1 @@
+<%= p('logstash_forwarder.ssl_ca_crt') %>

--- a/jobs/logstash_forwarder/templates/config/ssl.crt.erb
+++ b/jobs/logstash_forwarder/templates/config/ssl.crt.erb
@@ -1,0 +1,1 @@
+<%= p('logstash_forwarder.ssl_crt') %>

--- a/jobs/logstash_forwarder/templates/config/ssl.crt.erb
+++ b/jobs/logstash_forwarder/templates/config/ssl.crt.erb
@@ -1,1 +1,1 @@
-<%= p('logstash_forwarder.ssl_crt') %>
+<%= p('logstash_forwarder.ssl_certificate') %>

--- a/jobs/logstash_forwarder/templates/config/ssl.key.erb
+++ b/jobs/logstash_forwarder/templates/config/ssl.key.erb
@@ -1,0 +1,1 @@
+<%= p('logstash_forwarder.ssl_key') %>

--- a/jobs/logstash_forwarder/templates/data/properties.sh.erb
+++ b/jobs/logstash_forwarder/templates/data/properties.sh.erb
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# job template binding variables
+
+# job name & index of this VM within cluster
+# e.g. JOB_NAME=redis, JOB_INDEX=0
+export NAME='<%= name %>'
+export JOB_INDEX=<%= index %>
+# full job name, like redis/0 or webapp/3
+export JOB_FULL="$NAME/$JOB_INDEX"

--- a/jobs/logstash_forwarder/templates/helpers/ctl_setup.sh
+++ b/jobs/logstash_forwarder/templates/helpers/ctl_setup.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+# Setup env vars and folders for the ctl script
+# This helps keep the ctl script as readable
+# as possible
+
+# Usage options:
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh JOB_NAME OUTPUT_LABEL
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar nginx
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+JOB_NAME=$1
+output_label=${2:-${JOB_NAME}}
+
+export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+chmod 755 $JOB_DIR # to access file via symlink
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
+
+source $JOB_DIR/helpers/ctl_utils.sh
+redirect_output ${output_label}
+
+export HOME=${HOME:-/home/vcap}
+
+# Add all packages' /bin & /sbin into $PATH
+for package_bin_dir in $(ls -d /var/vcap/packages/*/*bin)
+do
+  export PATH=${package_bin_dir}:$PATH
+done
+
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_bin_dir in $(ls -d /var/vcap/packages/*/lib)
+do
+  export LD_LIBRARY_PATH=${package_bin_dir}:$LD_LIBRARY_PATH
+done
+
+# Setup log, run and tmp folders
+
+export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
+export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
+export STORE_DIR=/var/vcap/store/$JOB_NAME
+for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR
+do
+  mkdir -p ${dir}
+  chown vcap:vcap ${dir}
+  chmod 775 ${dir}
+done
+export TMPDIR=$TMP_DIR
+
+export C_INCLUDE_PATH=/var/vcap/packages/mysqlclient/include/mysql:/var/vcap/packages/sqlite/include:/var/vcap/packages/libpq/include
+export LIBRARY_PATH=/var/vcap/packages/mysqlclient/lib/mysql:/var/vcap/packages/sqlite/lib:/var/vcap/packages/libpq/lib
+
+# consistent place for vendoring python libraries within package
+if [[ -d ${WEBAPP_DIR:-/xxxx} ]]
+then
+  export PYTHONPATH=$WEBAPP_DIR/vendor/lib/python
+fi
+
+if [[ -d /var/vcap/packages/java7 ]]
+then
+  export JAVA_HOME="/var/vcap/packages/java7"
+fi
+
+# setup CLASSPATH for all jars/ folders within packages
+export CLASSPATH=${CLASSPATH:-''} # default to empty
+for java_jar in $(ls -d /var/vcap/packages/*/*/*.jar)
+do
+  export CLASSPATH=${java_jar}:$CLASSPATH
+done
+
+PIDFILE=$RUN_DIR/$output_label.pid
+
+echo '$PATH' $PATH

--- a/jobs/logstash_forwarder/templates/helpers/ctl_utils.sh
+++ b/jobs/logstash_forwarder/templates/helpers/ctl_utils.sh
@@ -1,0 +1,156 @@
+# Helper functions used by ctl scripts
+
+# links a job file (probably a config file) into a package
+# Example usage:
+# link_job_file_to_package config/redis.yml [config/redis.yml]
+# link_job_file_to_package config/wp-config.php wp-config.php
+link_job_file_to_package() {
+  source_job_file=$1
+  target_package_file=${2:-$source_job_file}
+  full_package_file=$WEBAPP_DIR/${target_package_file}
+
+  link_job_file ${source_job_file} ${full_package_file}
+}
+
+# links a job file (probably a config file) somewhere
+# Example usage:
+# link_job_file config/bashrc /home/vcap/.bashrc
+link_job_file() {
+  source_job_file=$1
+  target_file=$2
+  full_job_file=$JOB_DIR/${source_job_file}
+
+  echo link_job_file ${full_job_file} ${target_file}
+  if [[ ! -f ${full_job_file} ]]
+  then
+    echo "file to link ${full_job_file} does not exist"
+  else
+    # Create/recreate the symlink to current job file
+    # If another process is using the file, it won't be
+    # deleted, so don't attempt to create the symlink
+    mkdir -p $(dirname ${target_file})
+    ln -nfs ${full_job_file} ${target_file}
+  fi
+}
+
+# If loaded within monit ctl scripts then pipe output
+# If loaded from 'source ../utils.sh' then normal STDOUT
+redirect_output() {
+  SCRIPT=$1
+  mkdir -p /var/vcap/sys/log/monit
+  exec 1>> /var/vcap/sys/log/monit/$SCRIPT.log
+  exec 2>> /var/vcap/sys/log/monit/$SCRIPT.err.log
+}
+
+pid_guard() {
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pid() {
+  pid=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  echo wait_pid $pid $try_kill $timeout $force $countdown
+  if [ -e /proc/$pid ]; then
+    if [ "$try_kill" = "1" ]; then
+      echo "Killing $pidfile: $pid "
+      kill $pid
+    fi
+    while [ -e /proc/$pid ]; do
+      sleep 0.1
+      [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+      if [ $timeout -gt 0 ]; then
+        if [ $countdown -eq 0 ]; then
+          if [ "$force" = "1" ]; then
+            echo -ne "\nKill timed out, using kill -9 on $pid... "
+            kill -9 $pid
+            sleep 0.5
+          fi
+          break
+        else
+          countdown=$(( $countdown - 1 ))
+        fi
+      fi
+    done
+    if [ -e /proc/$pid ]; then
+      echo "Timed Out"
+    else
+      echo "Stopped"
+    fi
+  else
+    echo "Process $pid is not running"
+    echo "Attempting to kill pid anyway..."
+    kill $pid
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    wait_pid $pid $try_kill $timeout $force
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+  if [[ -f ${pidfile} ]]
+  then
+    wait_pidfile $pidfile 1 $timeout $force
+  else
+    # TODO assume $1 is something to grep from 'ps ax'
+    pid="$(ps auwwx | grep "$1" | awk '{print $2}')"
+    wait_pid $pid 1 $timeout $force
+  fi
+}
+
+check_nfs_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}

--- a/packages/logstash-forwarder/packaging
+++ b/packages/logstash-forwarder/packaging
@@ -1,0 +1,9 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+
+cp logstash/logstash-forwarder-1.4.0.rc1 $BOSH_INSTALL_TARGET/logstash-forwarder

--- a/packages/logstash-forwarder/packaging
+++ b/packages/logstash-forwarder/packaging
@@ -7,3 +7,4 @@ set -u # report the usage of uninitialized variables
 
 
 cp logstash/logstash-forwarder-1.4.0.rc1 $BOSH_INSTALL_TARGET/logstash-forwarder
+chmod +x $BOSH_INSTALL_TARGET/logstash-forwarder

--- a/packages/logstash-forwarder/spec
+++ b/packages/logstash-forwarder/spec
@@ -1,0 +1,5 @@
+---
+name: logstash-forwarder
+dependencies: []
+files:
+  - logstash/logstash-forwarder-1.4.0.rc1

--- a/releases/index.yml
+++ b/releases/index.yml
@@ -6,5 +6,7 @@ builds:
     version: 2
   1695c2b52cffc5ebef1df48d89e333c4d633fa9c:
     version: 3
-  !binary "NzI0MDc0M2IyYTQ1NDc5Y2U3ZDQ3NGU1ZTM3YzllYWM2ZDJjZjdkNQ==":
+  7240743b2a45479ce7d474e5e37c9eac6d2cf7d5:
     version: 4
+  3bd41103a032ef47188b44ff492a24a043641e35:
+    version: 5

--- a/releases/logsearch-5.yml
+++ b/releases/logsearch-5.yml
@@ -1,0 +1,74 @@
+---
+packages:
+- name: collectd
+  version: 1
+  sha1: 11e71da90541c290eeae6a871e382fbad3eebdb0
+  fingerprint: 54cd62ee75b2a4d8b67062f441586260fbeee20f
+  dependencies: []
+- name: elasticsearch
+  version: 2
+  sha1: 1d9c26287fd045904721a7c3fc73585107bfa29d
+  fingerprint: 01282319354bfdf955f4624a1477e10381cdb32e
+  dependencies: []
+- name: java7
+  version: 1
+  sha1: a8ab8d3c0df6b3e3254f0cae9606e1e7732c40dc
+  fingerprint: fbade6988160bd8576d4c1c44a0eb049d700858f
+  dependencies: []
+- name: logstash
+  version: 1
+  sha1: 31570e4f6c40795f66bad1644d82769a1d8877be
+  fingerprint: b4ca5e79b0441b8847f8238568ecf811b84a290b
+  dependencies: []
+- name: logstash-filters-common
+  version: 1
+  sha1: f229859c78c3720b1f288372b0e75478e73801fc
+  fingerprint: 2bcea31072695b15636f306ec6deb28650876ed5
+  dependencies: []
+- name: nginx
+  version: 2
+  sha1: b238042588d242ee5cea6e8f30b49be0e7fcf1d7
+  fingerprint: 0a474962510772b2b7e5922c5dc61e7d8e86c4b6
+  dependencies: []
+- name: redis
+  version: 1
+  sha1: 9af9f613fddccf158db3dfa63af8b1b1ca2b30f7
+  fingerprint: e2a4ec718365fd8ff2a2df1efbb13e6f82f94855
+  dependencies: []
+jobs:
+- name: api
+  version: 3
+  fingerprint: 858302bf14826a83697bb70a27200d5092263806
+  sha1: c32c2af121f05f7eff03bfa252c16db3568d4a76
+- name: collectd
+  version: 1
+  fingerprint: ec57dd2ad0199c989dc17c3777187e88c51f2464
+  sha1: 4ef336c63015991e31d03bdef380db0e52c691ca
+- name: elasticsearch
+  version: 2
+  fingerprint: aab64e5cdd256fe1eeffdfe4d7073efb54a18766
+  sha1: f85060405a0d7d4c0bcdc463dd0d888216aa0b4e
+- name: ingestor_lumberjack
+  version: 2
+  fingerprint: 273981e0d5363710424b8886ac70819910a629b0
+  sha1: 04bea0d9e0aeadba876a50de67488bc4db135125
+- name: ingestor_relp
+  version: 2
+  fingerprint: 361393b2cd51bc7762467ec6cea6e4c95f9606d9
+  sha1: 5090de3d35fb1c5b3171e49556b24e15f121ee87
+- name: ingestor_syslog
+  version: 2
+  fingerprint: 82e6f0f64325a9b08ddab4e281a8ab6556bc850d
+  sha1: b7c8202b1c4551e1493316aa2c9bbbb74842a76c
+- name: log_parser
+  version: 3
+  fingerprint: afb88b7309e3a1caa7e562c6767d288c7a630346
+  sha1: 668b8773cdd2ea23711c6fd8aa2074db613c14a7
+- name: queue
+  version: 2
+  fingerprint: 0a2fe2f3ecbac9014d5e5d190b4f331f79761930
+  sha1: d13e7d5e45becc1db04b97ab700c456aef72ae8a
+commit_hash: 56b531d3
+uncommitted_changes: true
+name: logsearch
+version: 5


### PR DESCRIPTION
This adds support for forwarding the elasticsearch request logs into another deployment (like we have setup on the old, active cluster).

I suppose we could make it forward every single monit stdout/stderr log and every other vcap-related log file, but I wasn't sure if we want to do that?

http://kibana-meta-logsearch-io.monitor-cloud.cityindextest5.co.uk/index.html#dashboard/temp/QDoiH4UWR9q8VhAB8z4L7w
