### PR TITLE
Switch to TCP/UDP inputs instead of syslog

### DIFF
--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -1,5 +1,10 @@
 input {
-	syslog {
+	tcp {
+		add_field => [ "type", "syslog" ]
+		host => "0.0.0.0"
+		port => "<%= p("logstash_ingestor.syslog.port") %>"
+	}
+	udp {
 		add_field => [ "type", "syslog" ]
 		host => "0.0.0.0"
 		port => "<%= p("logstash_ingestor.syslog.port") %>"


### PR DESCRIPTION
The syslog input causes _grokparsfailures due to CF messages not matching the
standard linux-syslog message format. Because of the failure, CF rules do not
come into effect.

https://github.com/elasticsearch/logstash/blob/1.3.x/lib/logstash/inputs/syslog.rb#L55-L69
https://github.com/logsearch/logstash-filters-cf/blob/master/src/100-cloudfoundry.conf.erb#L8
