### PR TITLE
Fix filter order when concatenating all the fragments

### DIFF
--- a/jobs/log_parser/templates/bin/log_parser_ctl
+++ b/jobs/log_parser/templates/bin/log_parser_ctl
@@ -20,10 +20,14 @@ case $1 in
     echo $$ > $PIDFILE
 
     # construct a complete config file from all the fragments
-    cat ${JOB_DIR}/config/input_redis_and_output_elasticsearch.conf > ${JOB_DIR}/config/all_inputs_outputs_filters.conf 
-    cat ${JOB_DIR}/config/filters_pre.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf 
-    cat /var/vcap/packages/logstash-filters-*/*.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf
-    cat ${JOB_DIR}/config/filters_post.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf 
+    cat ${JOB_DIR}/config/input_redis_and_output_elasticsearch.conf > ${JOB_DIR}/config/all_inputs_outputs_filters.conf
+    cat ${JOB_DIR}/config/filters_pre.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf
+
+    # find additional filters
+    FILTERS=$(find /var/vcap/packages/ -path '*logstash-filters*' -follow -type f -name '*.conf' | awk -vFS=/ -vOFS=, '{ print $NF,$0 }' | sort -n | cut -d "," -f 2 | xargs)
+    cat ${FILTERS} >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf
+
+    cat ${JOB_DIR}/config/filters_post.conf >> ${JOB_DIR}/config/all_inputs_outputs_filters.conf
 
     exec /var/vcap/packages/java7/bin/java -jar /var/vcap/packages/logstash/logstash.jar agent \
          -f ${JOB_DIR}/config/all_inputs_outputs_filters.conf -w ${LOGSTASH_WORKERS} \


### PR DESCRIPTION
The current command (cat /var/vcap/packages/logstash-filters-_/_.conf ) results in the following order:

```
/var/vcap/packages/logstash-filters-cf/100-cloudfoundry.conf
/var/vcap/packages/logstash-filters-common/75-elasticsearch_request.conf
/var/vcap/packages/logstash-filters-common/75-nginx_combined.conf
```

From my understanding, the desired state is to have it like so:

```
/var/vcap/packages/logstash-filters-common/75-elasticsearch_request.conf
/var/vcap/packages/logstash-filters-common/75-nginx_combined.conf
/var/vcap/packages/logstash-filters-cf/100-cloudfoundry.conf
```

This would be more pronounced if more filters existed with varying numering scheme between the different folders, for example:

```
/var/vcap/packages/logstash-filters-cf/30-third_filter.conf
/var/vcap/packages/logstash-filters-cf/100-cloudfoundry.conf
/var/vcap/packages/logstash-filters-common/20-second_filter.conf
/var/vcap/packages/logstash-filters-common/75-elasticsearch_request.conf
/var/vcap/packages/logstash-filters-common/75-nginx_combined.conf
/var/vcap/packages/logstash-filters-xyz/10-first_filter.conf
```

The find fixes this by sorting based on filename alone, irrespective of the folder it sits in (even if they were subfolders).
