### PR TITLE
Allow elasticsearch node tags

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -23,6 +23,8 @@ properties:
   elasticsearch.node.allow_data:
     description: Allow node to store data? (true / false)
     default: true
+  elasticsearch.node.tags:
+    description: A hash of additional tags for the node
   elasticsearch.exec.environment:
     description: A hash of additional environment variables for the process
   elasticsearch.exec.options:

--- a/jobs/elasticsearch/templates/config/default.json.erb
+++ b/jobs/elasticsearch/templates/config/default.json.erb
@@ -10,6 +10,9 @@
   "node" : {
     "master" : <%= p("elasticsearch.node.allow_master") %>,
     "data" : <%= p("elasticsearch.node.allow_data") %>
+    <% p("elasticsearch.node.tags", {}).each do | k, v | %>,
+      "<%= k %>" : "<%= v %>"
+    <% end %>
   },
   "discovery.zen.ping.multicast.enabled": false,
 <% if_p("elasticsearch.host") do %>


### PR DESCRIPTION
This adds support for applying arbitrary tags to elasticsearch nodes. For example:

```
properties:
  elasticsearch:
    node:
      tags:
        availability_zone: us-east-1a
```

The tags can later be used for index and [shard allocations](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-cluster.html#allocation-filtering).
