### PR TITLE
Micro-logsearch

### DIFF
--- a/.final_builds/jobs/elasticsearch/index.yml
+++ b/.final_builds/jobs/elasticsearch/index.yml
@@ -17,3 +17,8 @@ builds:
     version: 4
     sha1: !binary |-
       NzcwYTQxZDBjMjJiMzJmZWM1YzJlYzk2NjY4NzRkMzM1ZmI2ZTA2ZQ==
+  !binary "MGZlYTc5MmMyNmQ1MGI1NzBjOGU3MDhlZWFkZGZkZWQ2YTRjZDYwMA==":
+    blobstore_id: 9b9c3320-31e0-4c0a-80f1-6803ef29fbb3
+    version: 5
+    sha1: !binary |-
+      ZjJmMGRjZTJmOTZiMjU4MjgwODQ1NjFlNDYyNTZkYTdmOWUzZGVjYg==

--- a/.final_builds/jobs/log_parser/index.yml
+++ b/.final_builds/jobs/log_parser/index.yml
@@ -18,3 +18,8 @@ builds:
     version: 4
     sha1: !binary |-
       YjBjYzQyMjVlYmIwODFmZDU4YzY2Mzg1NGUxMmVkYjFmYmRkMDM4Nw==
+  !binary "ZTdhMWZkYTNiNjg1NWQ0MjEyMTBkYmRhNDA5ZWY2M2IwYTUyOTUwMA==":
+    blobstore_id: e88eff2f-3702-473a-af4e-27d6b010f138
+    version: 5
+    sha1: !binary |-
+      YmU2MGQ0N2ZjZjdhNTc5NTk2YmQxNWFhZWNlZWVmZDRjMTgyMTg3OA==

--- a/.final_builds/packages/logstash/index.yml
+++ b/.final_builds/packages/logstash/index.yml
@@ -4,3 +4,8 @@ builds:
     blobstore_id: a4602db9-f0d0-4cba-b295-e465d994db4b
     version: 1
     sha1: 31570e4f6c40795f66bad1644d82769a1d8877be
+  !binary "YzNhMDM3YWRmODk3MzAwODMxNmFiMTFjMmM1YWM4YjhkOGYwMjUxMQ==":
+    blobstore_id: 845dc2d4-ca2e-45dc-b108-7bc1922871cb
+    version: 2
+    sha1: !binary |-
+      ODdhNGU5NGQwNGU5YjcxNDc2YjRmYzlhODlhZGViNzVhZDMwMzMzMg==

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+### [2014-05-20] releases/logsearch-9.yml
+
+* `#24` - Allow elasticsearch node tags 
+* `#20` - Pull in additional logstash filters from `tar/tar.gz/zip` urls defined in `logstash_parser.filters` array.  

--- a/examples/micro-logsearch-bosh-lite.yml
+++ b/examples/micro-logsearch-bosh-lite.yml
@@ -1,0 +1,146 @@
+---
+name: logsearch
+director_uuid: f0588560-08a8-4ae2-914a-b9e8b12d9303 
+
+releases:
+- name: logsearch
+  version: 9
+
+compilation:
+  workers: 3
+  network: default
+  reuse_compilation_vms: true
+  cloud_properties: {}
+
+update:
+  serial: false #Deploy jobs in parallel
+  canaries: 1
+  canary_watch_time: 30000
+  update_watch_time: 30000
+  max_in_flight: 4
+  max_errors: 1
+
+resource_pools:
+- name: warden
+  network: default
+  size: 1
+  stemcell:
+    name: bosh-warden-boshlite-ubuntu
+    version: latest
+  cloud_properties: {}
+
+jobs:
+- name: logsearch
+  release: logsearch
+  templates: 
+  - name: api
+  - name: elasticsearch
+  - name: ingestor_lumberjack
+  - name: ingestor_syslog
+  - name: ingestor_relp
+  - name: queue
+  - name: log_parser
+  instances: 1
+  resource_pool: warden
+  networks:
+  - name: default
+    static_ips:
+    - 10.244.2.26
+  persistent_disk: 1024
+  properties:
+    logstash_forwarder:
+      job_files:
+      - path: /var/vcap/sys/log/elasticsearch/requests.log
+        type: elasticsearch_request
+      - path: /var/vcap/sys/log/api/nginx.access.log
+        type: nginx_access
+      - path: /var/vcap/sys/log/api/nginx.error.log
+        type: nginx_error
+properties: 
+  elasticsearch:
+    host: 10.244.2.26
+    cluster_name: micro-logsearch
+    indices:
+      ttl_interval: "5m"  # We want documents from test runs to be cleaned up frequently
+    index:
+      number_of_replicas: 0 # There is only one ES node in a micro-logsearch, so we can't have any replicas
+    exec:
+      environment:
+        ES_HEAP_SIZE: 256M
+  redis:
+    host: 10.244.2.26
+  logstash_parser:
+    debug: true
+    filters: []
+  logstash_ingestor:
+    debug: true
+    relp:
+      port: 5515
+    syslog:
+      port: 5514
+    lumberjack:
+      ssl_certificate: |
+          -----BEGIN CERTIFICATE-----
+          MIICsDCCAhmgAwIBAgIJAJZZlYOII804MA0GCSqGSIb3DQEBBQUAMEUxCzAJBgNV
+          BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
+          aWRnaXRzIFB0eSBMdGQwHhcNMTQwNDA4MTUxNzA3WhcNMjQwNDA1MTUxNzA3WjBF
+          MQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50
+          ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKB
+          gQC2xI0wD26YOIEukuyokWDkKsFEvZxnadOEGT/9isf/mdiMk10NRZTF5bZU9ek9
+          Vj9HsO7sk2ays31bkjQVAw9/l2eQSDNKtnnWk28AiTEOvZq5ZYnc9PT5uyHQL4Uj
+          XJe2H8Dg/gfJhy9Ru9gpSSnRkYOXnwp2v6eJiQtzC6EG0QIDAQABo4GnMIGkMB0G
+          A1UdDgQWBBSyMMgqdi6u092zAgm03c0/JhP0bDB1BgNVHSMEbjBsgBSyMMgqdi6u
+          092zAgm03c0/JhP0bKFJpEcwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgTClNvbWUt
+          U3RhdGUxITAfBgNVBAoTGEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZIIJAJZZlYOI
+          I804MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADgYEAif7W/VbSZ9GHfNDP
+          Cf+dsFTBk/1MpPW0cHXCX2lza42kbZ29PmhW1DSD+LkDcodL5wdVvTKSvJKmi5Cz
+          Y4O5DFyRcLQVTrhlUWfnUxTmaeWWzWyZe4RI98tTc2QHli6S9aeqczpa8k1aTiDp
+          XDPsPhpJjIepHXFRDaXUoV/T984=
+          -----END CERTIFICATE-----
+      ssl_key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          MIICWwIBAAKBgQC2xI0wD26YOIEukuyokWDkKsFEvZxnadOEGT/9isf/mdiMk10N
+          RZTF5bZU9ek9Vj9HsO7sk2ays31bkjQVAw9/l2eQSDNKtnnWk28AiTEOvZq5ZYnc
+          9PT5uyHQL4UjXJe2H8Dg/gfJhy9Ru9gpSSnRkYOXnwp2v6eJiQtzC6EG0QIDAQAB
+          AoGASnrQmnw/cnLcWfFv1cXguTqfJfcrDI14r8VmaVkr5YJ5V9gZvHXVicvxwK+x
+          y9gg04NL6karPDme5TkwVju4DXJxwcT70QhFOG5EHFxij1HA8hgOU+K4X4FeNVbz
+          JPi27ktnJTsYs2Hq/UMoWygTvlTtyCsCytcAuo5jZRoy/cECQQDxoeFJiIH6hn2M
+          G/89USPeJKfiXIP8pSZCZi/FagVHRYKhgJ2MY4Uw4bmIxyiMO9VGSXhDpbnx1AAp
+          /6/KOod5AkEAwaKjDcI4c87DRQfPdORNBoKPTY1CuLgYUTIKBDUYUG0d/Vwy+USA
+          0NJI74B6sLCdfxLtK1d95XVuLRPDDGksGQJAMm0zI/JuFcdtegj5umUtlBWYR8BA
+          9z/L/T1wKMXYdihGe8fomTzHtgzVeHr/tkxiVPnONGfop1Qz+I/Yst6GGQJANAJ+
+          L1zikuCPfIQrieckdUIuQZNWv4zbIzwAir7EKB4W9w2Dt4ZZ3z0MUCA/VCQsOYyY
+          3ZJjg3V2QW9UbYn2SQJAMwhKLGhbuv5ge5K5H436Rl0NR2nZVaIgxez0Y8tVeTBT
+          rM8ETzoKmuLdiTl3uUhgJMtdOP8w7geYl8o1YP+3YQ==
+          -----END RSA PRIVATE KEY-----
+
+
+# Warden CPI requires crappy network settings; so "hide" them away here
+networks:
+- name: default
+  # Assumes up to 7 VMs, including 4 static and 3 dynamic.
+  # Plus 7 (double the size) unused IPs, due to BOSH bug/quirk.
+  subnets:
+  - cloud_properties:
+      name: random
+    range: 10.244.2.24/30
+    reserved:
+    - 10.244.2.25
+    static:
+    - 10.244.2.26
+
+  # Bonus double-sized network required due to BOSH oddity
+  - cloud_properties:
+      name: random
+    range: 10.244.2.52/30
+    reserved:
+    - 10.244.2.53
+    static: []
+
+apply_spec:
+  properties:
+    ntp:
+      - 0.europe.pool.ntp.org
+      - 1.europe.pool.ntp.org
+      - 2.europe.pool.ntp.org
+      - 3.europe.pool.ntp.org

--- a/releases/index.yml
+++ b/releases/index.yml
@@ -16,3 +16,5 @@ builds:
     version: 7
   !binary "MzUzMjRkNjNmOGU1YzM0N2IzMGIxNGY4NzQxMWVmZmRiNTc2Njk4Ng==":
     version: 8
+  !binary "YWVmYWIzYjVkOTA0MDE0OTdmNTAyNTQyZDRhZmI5NmI0YzcyMThlMg==":
+    version: 9

--- a/releases/logsearch-9.yml
+++ b/releases/logsearch-9.yml
@@ -1,0 +1,110 @@
+---
+packages:
+- name: collectd
+  version: 1
+  sha1: !binary |-
+    MTFlNzFkYTkwNTQxYzI5MGVlYWU2YTg3MWUzODJmYmFkM2VlYmRiMA==
+  fingerprint: !binary |-
+    NTRjZDYyZWU3NWIyYTRkOGI2NzA2MmY0NDE1ODYyNjBmYmVlZTIwZg==
+  dependencies: []
+- name: elasticsearch
+  version: 3
+  sha1: !binary |-
+    ZmM2YzdiMTgyZWRmNTg3ZDYxNDc4NTQ4YjFlNmI4YTllOWZlMDViNw==
+  fingerprint: !binary |-
+    ZTE3ZjkxMmVmNDVmZWMxNDExZTc5ZTMxZDM1NjBmNGQ3MDJjY2VlZg==
+  dependencies: []
+- name: java7
+  version: 1
+  sha1: !binary |-
+    YThhYjhkM2MwZGY2YjNlMzI1NGYwY2FlOTYwNmUxZTc3MzJjNDBkYw==
+  fingerprint: !binary |-
+    ZmJhZGU2OTg4MTYwYmQ4NTc2ZDRjMWM0NGEwZWIwNDlkNzAwODU4Zg==
+  dependencies: []
+- name: logstash
+  version: 2
+  sha1: !binary |-
+    ODdhNGU5NGQwNGU5YjcxNDc2YjRmYzlhODlhZGViNzVhZDMwMzMzMg==
+  fingerprint: !binary |-
+    YzNhMDM3YWRmODk3MzAwODMxNmFiMTFjMmM1YWM4YjhkOGYwMjUxMQ==
+  dependencies: []
+- name: logstash-forwarder
+  version: 1
+  sha1: !binary |-
+    Yjc4YjI4MDQxODhiOTU2Yjk1N2U5NjkwMTM4Njg3NzczYzdkMTViNw==
+  fingerprint: !binary |-
+    YjE1YTMxZTk5YTg4ZmZkNWM4YzIzNGZhZWYyOWI2ZGJkNjI5MWE3Mw==
+  dependencies: []
+- name: nginx
+  version: 2
+  sha1: !binary |-
+    YjIzODA0MjU4OGQyNDJlZTVjZWE2ZThmMzBiNDliZTBlN2ZjZjFkNw==
+  fingerprint: !binary |-
+    MGE0NzQ5NjI1MTA3NzJiMmI3ZTU5MjJjNWRjNjFlN2Q4ZTg2YzRiNg==
+  dependencies: []
+- name: redis
+  version: 1
+  sha1: !binary |-
+    OWFmOWY2MTNmZGRjY2YxNThkYjNkZmE2M2FmOGIxYjFjYTJiMzBmNw==
+  fingerprint: !binary |-
+    ZTJhNGVjNzE4MzY1ZmQ4ZmYyYTJkZjFlZmJiMTNlNmY4MmY5NDg1NQ==
+  dependencies: []
+jobs:
+- name: api
+  version: 4
+  fingerprint: !binary |-
+    MzNhYTUzZWUyM2FkMjU2NjM3OGYxNGE0ODI3NWQ1ZGMxMmUzNDFiMg==
+  sha1: !binary |-
+    ZjJiYThkNDFkODkzYjhhNjM3OTY0NjE4ZmVkNmIyYmU3ODhkODZlOA==
+- name: collectd
+  version: 1
+  fingerprint: !binary |-
+    ZWM1N2RkMmFkMDE5OWM5ODlkYzE3YzM3NzcxODdlODhjNTFmMjQ2NA==
+  sha1: !binary |-
+    NGVmMzM2YzYzMDE1OTkxZTMxZDAzYmRlZjM4MGRiMGU1MmM2OTFjYQ==
+- name: elasticsearch
+  version: 5
+  fingerprint: !binary |-
+    MGZlYTc5MmMyNmQ1MGI1NzBjOGU3MDhlZWFkZGZkZWQ2YTRjZDYwMA==
+  sha1: !binary |-
+    ZjJmMGRjZTJmOTZiMjU4MjgwODQ1NjFlNDYyNTZkYTdmOWUzZGVjYg==
+- name: ingestor_lumberjack
+  version: 3
+  fingerprint: !binary |-
+    OGJmYWQ1NDNlMjc5MTAxZmM3MjVmMjhkZDA2NTA5MTJjODc4OWMxZQ==
+  sha1: !binary |-
+    MzBhY2E4MDQyOTdiMDk0NTEwOWMxYTllZmEzNjdlNTdlNDVjODkyYg==
+- name: ingestor_relp
+  version: 3
+  fingerprint: !binary |-
+    MTg3OWRlZWIzMjU0Yjk4ZDk2ZjZkNDQ3MWZlNzI4OTM1MWYwOGRhYQ==
+  sha1: !binary |-
+    YzZhMWQwZDZmMjdkZDEzOWIzNjY3NDZmMmRhZjc3MzBlNThlM2UxYg==
+- name: ingestor_syslog
+  version: 3
+  fingerprint: !binary |-
+    M2NmZTRmN2QyZTJjMzdhZjVkM2YxMmMzYjA0N2MwYmY5ZGRmZmM1Ng==
+  sha1: !binary |-
+    YWMzZjg3NmNhOTU2MmEzZjBlYjY4MTg3NmMzNzI3NTEzYWE0OGQ1ZQ==
+- name: log_parser
+  version: 5
+  fingerprint: !binary |-
+    ZTdhMWZkYTNiNjg1NWQ0MjEyMTBkYmRhNDA5ZWY2M2IwYTUyOTUwMA==
+  sha1: !binary |-
+    YmU2MGQ0N2ZjZjdhNTc5NTk2YmQxNWFhZWNlZWVmZDRjMTgyMTg3OA==
+- name: logstash_forwarder
+  version: 1
+  fingerprint: !binary |-
+    ZWE0YjkyYTFjYjkzNjRkOTlhYjRhYTk2NzNlNDlhM2NjZTA3MjQxMg==
+  sha1: !binary |-
+    Y2JkYTlmZjM0MGUxZTExZDgwMjVkOWJlYzI0NjU5ZmJkZGIwMzM1NQ==
+- name: queue
+  version: 2
+  fingerprint: !binary |-
+    MGEyZmUyZjNlY2JhYzkwMTRkNWU1ZDE5MGI0ZjMzMWY3OTc2MTkzMA==
+  sha1: !binary |-
+    ZDEzZTdkNWU0NWJlY2MxZGIwNGI5N2FiNzAwYzQ1NmFlZjcyYWU4YQ==
+commit_hash: 7be2134f
+uncommitted_changes: true
+name: logsearch
+version: 9


### PR DESCRIPTION
A sample deployment manifest for a "Micro-logsearch" - that is, where all logsearch components are installed on a single job / VM instance
