### PR TITLE
Add drain script for elasticsearch

### DIFF
--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -17,7 +17,7 @@ update:
   canaries: 1
   canary_watch_time: 30000
   update_watch_time: 30000
-  max_in_flight: 4
+  max_in_flight: 1
   max_errors: 1
 
 resource_pools:
@@ -33,9 +33,11 @@ jobs:
 - name: api
   release: logsearch
   templates: 
+  - name: elasticsearch
   - name: api
   - name: collectd
-  - name: elasticsearch
+  update:
+    serial: true
   instances: 1
   resource_pool: warden
   networks:
@@ -104,8 +106,10 @@ jobs:
 - name: elasticsearch_persistent
   release: logsearch
   templates:
-  - name: collectd
   - name: elasticsearch
+  - name: collectd
+  update:
+    serial: true
   instances: 1
   resource_pool: warden
   networks:
@@ -124,8 +128,10 @@ jobs:
 - name: elasticsearch_autoscale
   release: logsearch
   templates:
-  - name: collectd
   - name: elasticsearch
+  - name: collectd
+  update:
+    serial: true
   instances: 1
   resource_pool: warden
   networks:

--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -1,6 +1,6 @@
 ---
 name: logsearch
-director_uuid: f0588560-08a8-4ae2-914a-b9e8b12d9303 
+director_uuid: c5f8d0da-f8ac-4918-a1a3-0a846fb97d09
 
 releases:
 - name: logsearch
@@ -158,6 +158,7 @@ properties:
   elasticsearch:
     host: 10.244.2.2
     cluster_name: logsearch--bosh-lite
+    drain: true
     indices:
       ttl_interval: "5m"  # We want documents from test runs to be cleaned up frequently
     exec:

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -4,6 +4,8 @@ packages:
 - elasticsearch
 - java7
 templates:
+  bin/drain.erb: bin/drain
+  bin/undrain.erb: bin/undrain
   bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger
   config/default.json.erb: config/default.json
@@ -13,6 +15,10 @@ templates:
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
 properties:
+  elasticsearch.drain:
+    description: Whether to use the built-in drain features to improve deployment reliability
+    # disabled while we do additional testing
+    default: false
   elasticsearch.host:
     description: The frontend elasticsearch node services should use.
   elasticsearch.cluster_name:

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -53,7 +53,7 @@ if ! nc -zw 8 localhost 9300 2>&1 > /dev/null ; then
     # in going offline
 
     proceed
-elif [ "green" == `wget -qO- --timeout 16 'localhost:9200/_cat/health?h=status'` ] ; then
+elif [ "green" == $(curl -s --max-time 16 'localhost:9200/_cat/health?h=status') ] ; then
     # cluster is green, so let's proceed
 
     JOB_STATUS=$(cat $STATE_JOB_STATUS)
@@ -82,7 +82,7 @@ elif [ "green" == `wget -qO- --timeout 16 'localhost:9200/_cat/health?h=status'`
         # since we're terminating, we really care about whether we're still
         # responsible for any shards
 
-        if [ "0" == `wget -qO- 'localhost:9200/_cat/shards?h=index,shard,node' | grep '<%= name %>/<%= index %>' | wc -l` ] ; then
+        if [ "0" == $(curl -s --max-time 32 'localhost:9200/_cat/shards?h=index,shard,node' | grep '<%= name %>/<%= index %>' | wc -l) ] ; then
             # this node has no more shards allocated to it, so it's safe to
             # shutdown
 

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# simple script for delaying job updates until the cluster is green
+# this lets us do kind of a rolling restart of elasticsearch nodes and avoid
+# noticeable downtime
+#
+# this uses two state files
+# 1) to store which task we're working on (update, shutdown)
+# 2) whether we've done a one-time handling of that task
+#
+# this is necessary because we don't want to make changes to the cluster until
+# it is green (which may not be the first time this script is invoked)
+#
+# this is obviously very simplistic... if/when you need to get fancy with your
+# cluster, you'll want to disable this for more advanced allocation and host
+# management tasks
+#
+# this is invoked somewhere around here:
+# https://github.com/cloudfoundry/bosh/blob/7a7e42312a6a1dce50b578be579f17d10797e556/bosh_agent/lib/bosh_agent/message/drain.rb#L172
+
+<% if !p('elasticsearch.drain') %>
+# elasticsearch.drain is disabled in the manifest
+echo "0"
+exit 0
+<% elsif !p('elasticsearch.node.allow_data') %>
+# this node does not contain data, so we can skip all these data-related tasks
+echo "0"
+exit 0
+<% end %>
+
+JOB_STATUS=$1
+
+STATE_JOB_STATUS=/var/vcap/jobs/elasticsearch/config/.boshdrain
+STATE_HANDLED=/var/vcap/jobs/elasticsearch/config/.boshdrainhandled
+
+function proceed {
+    [ ! -f $STATE_JOB_STATUS ] || rm $STATE_JOB_STATUS
+    [ ! -f $STATE_HANDLED ] || rm $STATE_HANDLED
+
+    echo "0"
+    exit 0
+}
+
+if [ "job_check_status" != "$JOB_STATUS" ] ; then
+    echo $JOB_STATUS > $STATE_JOB_STATUS
+fi
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+if ! nc -zw 8 localhost 9300 2>&1 > /dev/null ; then
+    # elasticsearch transport isn't already online, so there should be no harm
+    # in going offline
+
+    proceed
+elif [ "green" == `wget -qO- --timeout 16 'localhost:9200/_cat/health?h=status'` ] ; then
+    # cluster is green, so let's proceed
+
+    JOB_STATUS=$(cat $STATE_JOB_STATUS)
+
+    if [ ! -f $STATE_HANDLED ] ; then
+        touch $STATE_HANDLED
+
+        if [ "job_changed" == "$JOB_STATUS" ] || [ "job_unchanged" == "$JOB_STATUS" ] ; then
+            # we should disable allocations to avoid indices getting reinitialized
+            # from peer shards while we're offline
+            curl -sX PUT -d '{"transient":{"cluster.routing.allocation.enable":"primaries"}}' 'localhost:9200/_cluster/settings' > /dev/null
+
+            # during startup, we'll look for this value to know if we should
+            # restore the normal allocation settings
+            curl -sX PUT -d '{"drained":1}' 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' > /dev/null
+        elif [ "job_shutdown" == "$JOB_STATUS" ] ; then
+            curl -sX PUT -d '{"transient":{"cluster.routing.allocation.exclude._name":"<%= name %>/<%= index %>"}}' 'localhost:9200/_cluster/settings' > /dev/null
+
+            # come back soon to check on the rebalancing status
+            echo "-10"
+            exit 0
+        fi
+    fi
+
+    if [ "job_shutdown" == "$JOB_STATUS" ] ; then
+        # since we're terminating, we really care about whether we're still
+        # responsible for any shards
+
+        if [ "0" == `wget -qO- 'localhost:9200/_cat/shards?h=index,shard,node' | grep '<%= name %>/<%= index %>' | wc -l` ] ; then
+            # this node has no more shards allocated to it, so it's safe to
+            # shutdown
+
+            proceed
+        fi
+
+        echo "-60"
+        exit 0
+    fi
+
+    proceed
+fi
+
+# check back again soon to see if the cluster is green
+echo "-10"
+exit 0

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -121,18 +121,18 @@ if [ ! -f $STATE_HANDLED ] ; then
         # this node will be simply be restarted
         #
 
-        # disable allocations while our node's shards go offline
-        curl -s \
-            -X PUT \
-            -d '{"transient":{"cluster.routing.allocation.enable":"primaries"}}' \
-            'localhost:9200/_cluster/settings' \
-            > /dev/null
-
         # set a flag so we know to reverse the setting when we start up again
         curl -s \
             -X PUT \
             -d '{"drained":1}' \
             'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' \
+            > /dev/null
+
+        # disable allocations while our node's shards go offline
+        curl -s \
+            -X PUT \
+            -d '{"transient":{"cluster.routing.allocation.enable":"primaries"}}' \
+            'localhost:9200/_cluster/settings' \
             > /dev/null
     elif [ "job_shutdown" == "$JOB_STATUS" ] ; then
         #

--- a/jobs/elasticsearch/templates/bin/drain.erb
+++ b/jobs/elasticsearch/templates/bin/drain.erb
@@ -1,101 +1,170 @@
 #!/bin/bash
 
-# simple script for delaying job updates until the cluster is green
-# this lets us do kind of a rolling restart of elasticsearch nodes and avoid
-# noticeable downtime
 #
-# this uses two state files
-# 1) to store which task we're working on (update, shutdown)
-# 2) whether we've done a one-time handling of that task
+# This script keeps the elasticsearch cluster stable when BOSH needs to manage
+# nodes during deploys. This is simplistic and only accounts for serial
+# changes to the elasticsearch nodes, so be sure elasticsearch jobs are
+# configured to deploy serially.
 #
-# this is necessary because we don't want to make changes to the cluster until
-# it is green (which may not be the first time this script is invoked)
+# When you get into fancier cluster scenarios, you'll want to disable this with
+# the `elasticsearch.drain: false` property and manage your own cluster
+# settings.
 #
-# this is obviously very simplistic... if/when you need to get fancy with your
-# cluster, you'll want to disable this for more advanced allocation and host
-# management tasks
-#
-# this is invoked somewhere around here:
+# This is invoked somewhere around here:
 # https://github.com/cloudfoundry/bosh/blob/7a7e42312a6a1dce50b578be579f17d10797e556/bosh_agent/lib/bosh_agent/message/drain.rb#L172
+#
 
-<% if !p('elasticsearch.drain') %>
-# elasticsearch.drain is disabled in the manifest
-echo "0"
-exit 0
-<% elsif !p('elasticsearch.node.allow_data') %>
-# this node does not contain data, so we can skip all these data-related tasks
-echo "0"
-exit 0
-<% end %>
+set -e
+set -u
 
 JOB_STATUS=$1
+
+<% if !p('elasticsearch.drain') %>
+#
+# The `elasticsearch.drain` property is disabled in the deployment.
+#
+
+echo "0"
+exit 0
+
+<% elsif !p('elasticsearch.node.allow_data') %>
+#
+# This node does not contain data, so we can skip all these tasks.
+#
+
+echo "0"
+exit 0
+
+<% end %>
+
+#
+# some state files we'll use
+#
 
 STATE_JOB_STATUS=/var/vcap/jobs/elasticsearch/config/.boshdrain
 STATE_HANDLED=/var/vcap/jobs/elasticsearch/config/.boshdrainhandled
 
-function proceed {
+
+#
+# some utility functions
+#
+
+function exit_cleanly {
+    #
+    # it's safe for us to shutdown
+    #
+
+    # clean up our state files
     [ ! -f $STATE_JOB_STATUS ] || rm $STATE_JOB_STATUS
     [ ! -f $STATE_HANDLED ] || rm $STATE_HANDLED
 
+    # done
     echo "0"
     exit 0
 }
 
+function exit_tryagain {
+    #
+    # bosh needs to check back later
+    #
+
+    echo "-10"
+    exit 0
+}
+
+
+#
+# ready, set, go...
+#
+
 if [ "job_check_status" != "$JOB_STATUS" ] ; then
+    #
+    # this is the first time bosh is running this drain script
+    #
+
+    # save the task for later (since subsequent calls are job_check_status)
     echo $JOB_STATUS > $STATE_JOB_STATUS
 fi
 
-set -e # exit immediately if a simple command exits with a non-zero status
-set -u # report the usage of uninitialized variables
-
 if ! nc -zw 8 localhost 9300 2>&1 > /dev/null ; then
-    # elasticsearch transport isn't already online, so there should be no harm
-    # in going offline
+    #
+    # elasticsearch transport is offline
+    #
 
-    proceed
-elif [ "green" == $(curl -s --max-time 16 'localhost:9200/_cat/health?h=status') ] ; then
-    # cluster is green, so let's proceed
+    # since we're not already online, it should be safe to stop elasticsearch
+    exit_cleanly
+elif [ "green" != $(curl -s 'localhost:9200/_cat/health?h=status' | tr -d '[:space:]') ] ; then
+    #
+    # the cluster is not yet stable
+    #
 
-    JOB_STATUS=$(cat $STATE_JOB_STATUS)
-
-    if [ ! -f $STATE_HANDLED ] ; then
-        touch $STATE_HANDLED
-
-        if [ "job_changed" == "$JOB_STATUS" ] || [ "job_unchanged" == "$JOB_STATUS" ] ; then
-            # we should disable allocations to avoid indices getting reinitialized
-            # from peer shards while we're offline
-            curl -sX PUT -d '{"transient":{"cluster.routing.allocation.enable":"primaries"}}' 'localhost:9200/_cluster/settings' > /dev/null
-
-            # during startup, we'll look for this value to know if we should
-            # restore the normal allocation settings
-            curl -sX PUT -d '{"drained":1}' 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' > /dev/null
-        elif [ "job_shutdown" == "$JOB_STATUS" ] ; then
-            curl -sX PUT -d '{"transient":{"cluster.routing.allocation.exclude._name":"<%= name %>/<%= index %>"}}' 'localhost:9200/_cluster/settings' > /dev/null
-
-            # come back soon to check on the rebalancing status
-            echo "-10"
-            exit 0
-        fi
-    fi
-
-    if [ "job_shutdown" == "$JOB_STATUS" ] ; then
-        # since we're terminating, we really care about whether we're still
-        # responsible for any shards
-
-        if [ "0" == $(curl -s --max-time 32 'localhost:9200/_cat/shards?h=index,shard,node' | grep '<%= name %>/<%= index %>' | wc -l) ] ; then
-            # this node has no more shards allocated to it, so it's safe to
-            # shutdown
-
-            proceed
-        fi
-
-        echo "-60"
-        exit 0
-    fi
-
-    proceed
+    # we need to wait before we try to run our drain tasks
+    exit_tryagain
 fi
 
-# check back again soon to see if the cluster is green
-echo "-10"
-exit 0
+#
+# cluster is green
+#
+
+JOB_STATUS=$(cat $STATE_JOB_STATUS)
+
+if [ ! -f $STATE_HANDLED ] ; then
+    #
+    # this is the first time drain has been called where the cluster is green
+    #
+
+    # set the flag to avoid running the one-time job tasks again
+    touch $STATE_HANDLED
+
+    if [ "job_changed" == "$JOB_STATUS" ] || [ "job_unchanged" == "$JOB_STATUS" ] ; then
+        #
+        # this node will be simply be restarted
+        #
+
+        # disable allocations while our node's shards go offline
+        curl -s \
+            -X PUT \
+            -d '{"transient":{"cluster.routing.allocation.enable":"primaries"}}' \
+            'localhost:9200/_cluster/settings' \
+            > /dev/null
+
+        # set a flag so we know to reverse the setting when we start up again
+        curl -s \
+            -X PUT \
+            -d '{"drained":1}' \
+            'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' \
+            > /dev/null
+    elif [ "job_shutdown" == "$JOB_STATUS" ] ; then
+        #
+        # this node (and its data) are going to be eliminated
+        #
+
+        # tell cluster it shouldn't trust us with data
+        curl -s \
+            -X PUT \
+            -d '{"transient":{"cluster.routing.allocation.exclude._name":"<%= name %>/<%= index %>"}}' \
+            'localhost:9200/_cluster/settings' \
+            > /dev/null
+
+        # we need to wait for elasticsearch to transfer shards off
+        exit_tryagain
+    fi
+fi
+
+if [ "job_shutdown" == "$JOB_STATUS" ] ; then
+    #
+    # this node (and its data) are going to be trashed
+    #
+
+    if [ "0" != $(curl -s 'localhost:9200/_cat/shards?h=index,shard,node' | grep '<%= name %>/<%= index %>' | wc -l) ] ; then
+        #
+        # this node still has data on it
+        #
+
+        # we still need to wait for elasticsearch to transfer shards off
+        exit_tryagain
+    fi
+fi
+
+# nothing more is stopping us from shutting down
+exit_cleanly

--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -22,6 +22,8 @@ case $1 in
   start)
     pid_guard $PIDFILE $JOB_NAME
 
+    /var/vcap/jobs/elasticsearch/bin/undrain 2>&1 >> $LOG_DIR/undrain.log &
+
     exec /var/vcap/packages/elasticsearch/bin/elasticsearch \
          -Des.config=${JOB_DIR}/config/default.json \
          -XX:HeapDumpPath=${TMPDIR}/heap-dump/ \

--- a/jobs/elasticsearch/templates/bin/undrain.erb
+++ b/jobs/elasticsearch/templates/bin/undrain.erb
@@ -33,7 +33,7 @@ while ! nc -zw 8 localhost 9200 2>&1 > /dev/null ; do sleep 5 ; done
 #
 READY=false
 while [ "false" == "$READY" ] ; do
-    STATUS=`curl -s 'localhost:9200/_cat/health?h=status' | tr -d '[:space:]'`
+    STATUS=$(curl -s 'localhost:9200/_cat/health?h=status' | tr -d '[:space:]')
 
     if [ "green" == "$STATUS" ] || [ "yellow" == "$STATUS" ] ; then
         READY=true
@@ -42,7 +42,7 @@ while [ "false" == "$READY" ] ; do
     fi
 done
 
-if [ '{"drained":1}' == `curl -s 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>/_source'` ] ; then
+if [ '{"drained":1}' == $(curl -s 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>/_source') ] ; then
     #
     # looks like the drain script was used, so reverse those settings
     #

--- a/jobs/elasticsearch/templates/bin/undrain.erb
+++ b/jobs/elasticsearch/templates/bin/undrain.erb
@@ -1,36 +1,62 @@
 #!/bin/bash
 
-# this script will re-enable shard allocations if the drain script was used
-# and caused allocations to be disabled
+#
+# This script will re-enable shard allocations if the drain script was used.
+#
+
+set -e
+set -u
 
 <% if !p('elasticsearch.drain') %>
-# elasticsearch.drain is disabled in the manifest
+#
+# The `elasticsearch.drain` property is disabled in the deployment.
+#
+
 exit 0
+
 <% elsif !p('elasticsearch.node.allow_data') %>
-# this node does not contain data, so we can skip all these data-related tasks
+#
+# This node does not contain data, so we can skip all these tasks.
+#
+
 exit 0
+
 <% end %>
 
-# this will be spawned before elasticsearch is ready, so we need to wait until
-# we can talk to it
+#
+# we need to wait until we can talk to elasticsearch
+#
 while ! nc -zw 8 localhost 9200 2>&1 > /dev/null ; do sleep 5 ; done
 
-# we should wait until our .bosh index is certainly available for reading
+#
+# we need to wait until the .bosh index is certainly available
+#
 READY=false
 while [ "false" == "$READY" ] ; do
-    STATUS=`wget -qO- --timeout 16 'localhost:9200/_cat/health?h=status'`
+    STATUS=`curl -s 'localhost:9200/_cat/health?h=status' | tr -d '[:space:]'`
 
-    if [ "green" != "$STATUS" ] && [ "yellow" != "$STATUS" ] ; then
+    if [ "green" == "$STATUS" ] || [ "yellow" == "$STATUS" ] ; then
         READY=true
     else
-        sleep 5
+        sleep 1
     fi
 done
 
-if [ '{"drained":1}' == `wget -qO- 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>/_source'` ]; then
-    # put allocations back to normal
-    curl -sX PUT -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' 'localhost:9200/_cluster/settings' > /dev/null
+if [ '{"drained":1}' == `curl -s 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>/_source'` ] ; then
+    #
+    # looks like the drain script was used, so reverse those settings
+    #
 
-    # and avoid us doing this next time
-    curl -sX DELETE 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' > /dev/null
+    # put allocations back to normal
+    curl -s \
+        -X PUT \
+        -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' \
+        'localhost:9200/_cluster/settings' \
+        > /dev/null
+
+    # avoid us doing this next time
+    curl -s \
+        -X DELETE \
+        'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' \
+        > /dev/null
 fi

--- a/jobs/elasticsearch/templates/bin/undrain.erb
+++ b/jobs/elasticsearch/templates/bin/undrain.erb
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# this script will re-enable shard allocations if the drain script was used
+# and caused allocations to be disabled
+
+<% if !p('elasticsearch.drain') %>
+# elasticsearch.drain is disabled in the manifest
+exit 0
+<% elsif !p('elasticsearch.node.allow_data') %>
+# this node does not contain data, so we can skip all these data-related tasks
+exit 0
+<% end %>
+
+# this will be spawned before elasticsearch is ready, so we need to wait until
+# we can talk to it
+while ! nc -zw 8 localhost 9200 2>&1 > /dev/null ; do sleep 5 ; done
+
+# we should wait until our .bosh index is certainly available for reading
+READY=false
+while [ "false" == "$READY" ] ; do
+    STATUS=`wget -qO- --timeout 16 'localhost:9200/_cat/health?h=status'`
+
+    if [ "green" != "$STATUS" ] && [ "yellow" != "$STATUS" ] ; then
+        READY=true
+    else
+        sleep 5
+    fi
+done
+
+if [ '{"drained":1}' == `wget -qO- 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>/_source'` ]; then
+    # put allocations back to normal
+    curl -sX PUT -d '{"transient":{"cluster.routing.allocation.enable":"all"}}' 'localhost:9200/_cluster/settings' > /dev/null
+
+    # and avoid us doing this next time
+    curl -sX DELETE 'localhost:9200/.bosh/drain/<%= name %>--<%= index %>' > /dev/null
+fi


### PR DESCRIPTION
This is the continuation and implementation of issue #51 with concrete changes to discuss. The goal is to support zero downtime of the elasticsearch cluster during deploys (which has been a significant problem).
