### PR TITLE
Adjust logstash.filters configuration

### DIFF
--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -1,6 +1,6 @@
 ---
 name: logsearch
-director_uuid: f0588560-08a8-4ae2-914a-b9e8b12d9303 
+director_uuid: c5f8d0da-f8ac-4918-a1a3-0a846fb97d09
 
 releases:
 - name: logsearch
@@ -162,6 +162,9 @@ properties:
   logstash_parser:
     debug: true
     filters:
+    # reuse the pre-packaged filters
+    - "file:///var/vcap/packages/logstash/default-filters"
+    # and add the separate cloudfoundry filters
     - "https://ci-logsearch.s3.amazonaws.com/logsearch-filters-cf/logstash-filters-cf-7.tgz"
   logstash_ingestor:
     debug: true

--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -161,11 +161,8 @@ properties:
     host: 10.244.2.10
   logstash_parser:
     debug: true
-    filters:
-    # reuse the pre-packaged filters
-    - "file:///var/vcap/packages/logstash/default-filters"
-    # and add the separate cloudfoundry filters
-    - "https://ci-logsearch.s3.amazonaws.com/logsearch-filters-cf/logstash-filters-cf-7.tgz"
+    #filters: |
+    #        <%# File.read('example.conf').gsub(/^/, '            ').strip %>
   logstash_ingestor:
     debug: true
     relp:

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -12,6 +12,8 @@ templates:
   config/input_redis_and_output_elasticsearch.conf.erb: config/input_redis_and_output_elasticsearch.conf
   config/filters_pre.conf.erb: config/filters_pre.conf
   config/filters_post.conf.erb: config/filters_post.conf
+  config/filters_default.conf: config/filters_default.conf
+  config/filters_override.conf.erb: config/filters_override.conf
 properties:
   logstash_parser.debug:
     description: Debug level logging
@@ -20,9 +22,8 @@ properties:
     description: "Maximum log message length.  Anything larger is truncated (TODO: move this to ingestor?)"
     default: 1048576
   logstash_parser.filters:
-    description: "A list of URL downloads (tar, tar.gz, zip) or local file directories"
-    default:
-    - "file:///var/vcap/packages/logstash/default-filters"
+    description: "The configuration to embed into the logstash filters section"
+    default: ''
   logstash_parser.workers:
     description: "The number of worker threads that logstash should use (default: auto = one per CPU)"
     default: auto

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -20,8 +20,9 @@ properties:
     description: "Maximum log message length.  Anything larger is truncated (TODO: move this to ingestor?)"
     default: 1048576
   logstash_parser.filters:
-    description: "A list of URL downloads (tar, tar.gz, zip)"
-    default: []
+    description: "A list of URL downloads (tar, tar.gz, zip) or local file directories"
+    default:
+    - "file:///var/vcap/packages/logstash/default-filters"
   logstash_parser.workers:
     description: "The number of worker threads that logstash should use (default: auto = one per CPU)"
     default: auto

--- a/jobs/log_parser/templates/bin/log_parser_ctl
+++ b/jobs/log_parser/templates/bin/log_parser_ctl
@@ -15,11 +15,6 @@ export LOGSTASH_WORKERS=`grep -c ^processor /proc/cpuinfo`
 export LOGSTASH_WORKERS=<%= p('logstash_parser.workers') %>
 <% end %>
 
-#Copy all files from source folder tree and flatten into dest folder
-function copy_and_flatten  {
-    find $1 -type f -exec cp {} $2 \;
-}  
-
 case $1 in
 
   start)
@@ -32,31 +27,11 @@ case $1 in
     cat ${JOB_DIR}/config/input_redis_and_output_elasticsearch.conf > ${JOB_DIR}/config/logstash.conf
     cat ${JOB_DIR}/config/filters_pre.conf >> ${JOB_DIR}/config/logstash.conf
 
-    mkdir -p ${JOB_DIR}/config/raw ${JOB_DIR}/config/composite
-    rm -f ${JOB_DIR}/config/composite/*
-
-    pushd ${JOB_DIR}/config/composite > /dev/null
-
-    <% filters = Array(p('logstash_parser.filters', [])) %>
-    <% filters.each do | v | %>
-      <% if v =~ /^file:\/\/(.+)$/ %>
-        find <%= $1 %> -name '*.conf' -exec cp {} . \;
-      <% else %>
-        <% if v =~ /\.tar\.gz$/ or v =~ /\.tgz$/ %>
-          /usr/bin/wget -qO- "<%= v %>" | /bin/tar -xz 
-        <% elsif v =~ /\.tar$/ %>
-          /usr/bin/wget -qO- "<%= v %>" | /bin/tar -x 
-        <% elsif v =~ /\.zip$/ %>
-          /usr/bin/wget "<%= v %>" && /usr/bin/unzip -d .ziptmp `basename "<%= v %>"` && /bin/mv .ziptmp/*/* ./ && /bin/rm -fr `basename "<%= v %>"` .ziptmp
-        <% end %>
-      <% end %>
+    <% if '' != p('logstash_parser.filters') %>
+      cat ${JOB_DIR}/config/filters_override.conf >> ${JOB_DIR}/config/logstash.conf
+    <% else %>
+      cat ${JOB_DIR}/config/filters_default.conf >> ${JOB_DIR}/config/logstash.conf
     <% end %>
-
-    popd > /dev/null
-
-    # find all filters
-    FILTERS=$(find ${JOB_DIR}/config/composite -follow -type f -name '*.conf' | awk -vFS=/ -vOFS=, '{ print $NF,$0 }' | sort -n | cut -d "," -f 2 | xargs)
-    cat ${FILTERS} >> ${JOB_DIR}/config/logstash.conf
 
     cat ${JOB_DIR}/config/filters_post.conf >> ${JOB_DIR}/config/logstash.conf
 

--- a/jobs/log_parser/templates/bin/log_parser_ctl
+++ b/jobs/log_parser/templates/bin/log_parser_ctl
@@ -35,23 +35,13 @@ case $1 in
     mkdir -p ${JOB_DIR}/config/raw ${JOB_DIR}/config/composite
     rm -f ${JOB_DIR}/config/composite/*
 
-    #fetch the standard filters (so they can be overwritten by logstash_parser.filters below if necessary)
-    copy_and_flatten /var/vcap/packages/logstash/logsearch-filters-common ${JOB_DIR}/config/composite
+    pushd ${JOB_DIR}/config/composite > /dev/null
 
-    <%
-      md5filters = p('logstash_parser.filters').map do | v |
-        Digest::MD5.hexdigest v
-      end
-    %>
-
-    pushd ${JOB_DIR}/config > /dev/null
-
-    <% p('logstash_parser.filters').each_with_index do | v, i | %>
-      # <%= v %>
-      if ! [[ -d raw/<%= md5filters[i] %> ]] ; then
-        mkdir -p raw/<%= md5filters[i] %>
-        pushd raw/<%= md5filters[i] %> > /dev/null
-
+    <% filters = Array(p('logstash_parser.filters', [])) %>
+    <% filters.each do | v | %>
+      <% if v =~ /^file:\/\/(.+)$/ %>
+        find <%= $1 %> -name '*.conf' -exec cp {} . \;
+      <% else %>
         <% if v =~ /\.tar\.gz$/ or v =~ /\.tgz$/ %>
           /usr/bin/wget -qO- "<%= v %>" | /bin/tar -xz 
         <% elsif v =~ /\.tar$/ %>
@@ -59,20 +49,8 @@ case $1 in
         <% elsif v =~ /\.zip$/ %>
           /usr/bin/wget "<%= v %>" && /usr/bin/unzip -d .ziptmp `basename "<%= v %>"` && /bin/mv .ziptmp/*/* ./ && /bin/rm -fr `basename "<%= v %>"` .ziptmp
         <% end %>
-
-        popd > /dev/null
-      fi
-
-      #Copy extracted filters into filter collection (overwriting is intentional)
-      copy_and_flatten raw/<%= md5filters[i] %> ${JOB_DIR}/config/composite
+      <% end %>
     <% end %>
-
-    # cleanup old filters
-    for FILTERMD5 in $(ls raw) ; do
-      if ! [[ " <%= md5filters.join(' ') %> " =~ " $FILTERMD5 " ]] ; then
-        rm -fr raw/$FILTERMD5
-      fi
-    done
 
     popd > /dev/null
 

--- a/jobs/log_parser/templates/config/filters_default.conf
+++ b/jobs/log_parser/templates/config/filters_default.conf
@@ -1,0 +1,167 @@
+# this is auto-generated from
+# https://github.com/logsearch/logsearch-filters-common
+# 703f23d4ef3532ef01cc0a07361efd131418b25d
+
+if [@type] in ["syslog", "relp"] {
+  # syslog/relp
+  
+  grok {
+      match => { "@message" => "(?:%{INT:syslog6587_msglen} )?<%{POSINT:syslog_pri}>(?:%{NONNEGINT:syslog5424_ver} )?(?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:syslog_timestamp}) %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?(:)? %{GREEDYDATA:syslog_message}" }
+      add_field => [ "received_at", "%{@timestamp}" ]
+      add_field => [ "received_from", "%{host}" ]
+      add_tag => [ "syslog_standard" ]
+      tag_on_failure => ["_grokparsefailure-syslog_standard"]
+  }
+  
+  if !("_grokparsefailure-syslog_standard" in [tags]) {
+      syslog_pri { }
+  
+      date {
+          match => [ "syslog_timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601" ]
+          timezone => "UTC"
+      }
+  
+      # hostname: handle syslog configurations where hostname is localhost
+      if ([syslog_hostname] == "localhost" ) {
+          grok {
+              match => { "received_from" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
+              overwrite => [ "syslog_hostname", "syslog_port" ]
+              tag_on_failure => [ "_grokparsefailure-syslog_standard-hostname"]
+          }
+      }
+  
+      mutate {
+          replace => [ "@source.host", "%{syslog_hostname}" ]
+      }
+  
+      mutate {
+          convert => [ "syslog5424_ver", "integer" ]
+          convert => [ "syslog6587_msglen", "integer" ]
+          remove_field => [
+              #"syslog_pri",
+              "syslog_hostname",
+              "syslog_port",
+              "syslog_timestamp"
+          ]
+      }
+  }
+
+}
+
+if [@type] == "syslog" and [syslog_message] =~ /^\- \- \[NXLOG/ {
+  grok {
+      match => [ "syslog_message", "\- \- \[NXLOG@14506 (?<shipper[source_params]>[^\]]+)\] %{GREEDYDATA:@message}" ]
+      overwrite => [
+          "@message"
+      ]
+      tag_on_failure => [ "_grokparsefailure-nxlog_standard" ]
+  }
+  
+  if "_grokparsefailure-nxlog_standard" not in [tags] {
+      # grok doesn't like @named groups
+      mutate {
+          rename => [ "shipper", "@shipper" ]
+      }
+  
+      kv {
+        source => "@shipper[source_params]"
+        target => "@source"
+      }
+  
+      mutate {
+          # syslog is just the transport; no need to store
+          remove_field => "syslog_message"
+          remove_field => "syslog_pri"
+          remove_field => "syslog5424_ver"
+          remove_field => "syslog_program"
+          remove_field => "syslog_severity_code"
+          remove_field => "syslog_facility_code"
+          remove_field => "syslog_facility"
+          remove_field => "syslog_severity"
+  
+          # syslog host is actually the shipper
+          rename => [ "@source.host", "@shipper[host]" ]
+  
+          # these arbitrary parameters are parsed to @source
+          remove_field => "@shipper[source_params]"
+  
+          # these are parsed with kv, but they're static nxlog shipper properties
+          rename => [ "@source[EventReceivedTime]", "@shipper[event_received_time" ]
+          rename => [ "@source[SourceModuleName]", "@shipper[module_name" ]
+          rename => [ "@source[SourceModuleType]", "@shipper[module_type" ]
+  
+          # @source[type] should replace the syslog @type
+          rename => [ "@source[type]", "@type" ]
+      }
+  }
+
+}
+
+if [@type] == "json" {
+  json {
+    source => "@message"
+  }
+  
+  date {
+    match => [ "timestamp", "ISO8601" ]
+    timezone => "UTC"
+  }
+  
+  
+  #
+  # typically message will be a string, so message_data is used as the object
+  #
+  
+  ruby {
+    code => "event['message_data'] = event.remove('message') if event.include?('message') and event['message'].is_a? Hash"
+  }
+  
+  if [@timestamp] {
+    #
+    # We ran into a situation where a shipper was sending an improperly formatted
+    # message into the logsearch cluster. It included a raw @timestamp field, but
+    # it was an array. This causes the logstash parsing process to completely block
+    # because it is unable to convert event['@timestamp'] since it expects a Time.
+    #
+    # This performs a check to ensure @timestamp is a Time, otherwise it renames
+    # the field to _timestamperror, adds a _timestamperror tag, and replaces
+    # @timestamp with the current time.
+    #
+  
+    ruby {
+      code => "if Time != event['@timestamp'].class ; event.tag('_timestamperror') ; event['_timestamperror'] = event['@timestamp'] ; event['@timestamp'] = Time.new ; end"
+    }
+  }
+
+}
+
+if [@type] == "elasticsearch_request" {
+  json {
+    source => "@message"
+  }
+  
+  mutate {
+    remove_field => [ 'day', 'dow', 'hour', 'minute', 'month', 'year' ]
+  }
+  
+  date {
+    match => [ "starttime", "ISO8601" ]
+    timezone => "UTC"
+  }
+
+}
+
+if [@type] == "nginx_combined" {
+  grok {
+    match => [ "@message", "%{IPORHOST:remote_addr} - (?:%{USER:remote_user}|-) \[%{HTTPDATE:time_local}\] \"(?:%{WORD:request_method} %{URIPATHPARAM:request_uri}(?: HTTP/%{NUMBER:request_httpversion})?|-)\" %{INT:status} (?:%{NONNEGINT:body_bytes_sent}|-) \"(?:%{URI:http_referer}|-)\" %{QS:http_user_agent} (?:%{NONNEGINT:request_time}|-)" ]
+    match => [ "@message", "%{IPORHOST:remote_addr} - (?:%{USER:remote_user}|-) \[%{HTTPDATE:time_local}\] \"(?:%{WORD:request_method} %{URIPATHPARAM:request_uri}(?: HTTP/%{NUMBER:request_httpversion})?|-)\" %{INT:status} (?:%{NONNEGINT:body_bytes_sent}|-) \"(?:%{URI:http_referer}|-)\" %{QS:http_user_agent}" ]
+    add_tag => "nginx"
+    tag_on_failure => [ "_grokparsefailure-nginx_combined" ]
+  }
+  
+  date {
+    match => [ "time_local", "dd/MMM/YYYY:HH:mm:ss Z" ]
+    timezone => "UTC"
+  }
+
+}

--- a/jobs/log_parser/templates/config/filters_override.conf.erb
+++ b/jobs/log_parser/templates/config/filters_override.conf.erb
@@ -1,0 +1,1 @@
+<%= p('logstash_parser.filters') %>

--- a/jobs/log_parser/templates/config/filters_pre.conf.erb
+++ b/jobs/log_parser/templates/config/filters_pre.conf.erb
@@ -59,5 +59,5 @@ filter {
     }
 
     #
-    # Additional filter types from /var/vcap/packages/logstash-filters-*/*.conf
+    # Additional filter types from deployment manifest
     #

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -9,6 +9,6 @@ mkdir $BOSH_INSTALL_TARGET/logstash
 tar -xzf logstash/logstash-1.4.1.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
 tar -xzf logstash/logstash-contrib-1.4.1.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
 
-mkdir -p $BOSH_INSTALL_TARGET/logsearch-filters-common
-/bin/tar --strip-components 1 -xzf logstash/logsearch-filters-common-16.tgz -C $BOSH_INSTALL_TARGET/logsearch-filters-common
+mkdir -p $BOSH_INSTALL_TARGET/default-filters
+/bin/tar --strip-components 1 -xzf logstash/logsearch-filters-common-16.tgz -C $BOSH_INSTALL_TARGET/default-filters
 

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -8,7 +8,3 @@ set -u # report the usage of uninitialized variables
 mkdir $BOSH_INSTALL_TARGET/logstash
 tar -xzf logstash/logstash-1.4.1.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
 tar -xzf logstash/logstash-contrib-1.4.1.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
-
-mkdir -p $BOSH_INSTALL_TARGET/default-filters
-/bin/tar --strip-components 1 -xzf logstash/logsearch-filters-common-16.tgz -C $BOSH_INSTALL_TARGET/default-filters
-

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -4,4 +4,3 @@ dependencies: []
 files: 
   - logstash/logstash-1.4.1.tar.gz
   - logstash/logstash-contrib-1.4.1.tar.gz
-  - logstash/logsearch-filters-common-16.tgz


### PR DESCRIPTION
This includes a few changes initiated by logsearch/logsearch-boshrelease#58...
- by default, embedded filters are no longer included if you specify your own filters (`example/warden.yml` provides an example to reuse them within a deployment)
- this adds support for `file://*` which will include `*.conf` files from the specified directory
- this simplifies the config building a little bit and allows `logstash.filters` to be either a string or array of location paths (if an array, files of the same name will overwrite earlier extractions)
