### PR TITLE
Add CI tasks that can be run in a Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 FROM dockerfile/ruby
 
-RUN apt-get install curl -y
-RUN bundle install #"2014-07-10"
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+ADD Gemfile /workspace/Gemfile
+ADD Gemfile.lock /workspace/Gemfile.lock
+RUN bundle install
 
 VOLUME ["/workspace"]
-WORKDIR /workspace

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ namespace :dev_release do
 	desc "Creates DEV release"
 	task :create do
 		puts "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-		sh "bosh #{target} create release --force"
+		sh "yes logsearch | bosh create release --force --with-tarball"
 	end
 	desc "Creates and uploads DEV release to currently targeted BOSH."
 	task :create_and_upload => :create do

--- a/Rakefile
+++ b/Rakefile
@@ -5,18 +5,27 @@ RSpec::Core::RakeTask.new('spec')
 # If you want to make this the default task
 task :default => :spec
 
+target=""
+target="#{target} -t #{ENV['BOSH_TARGET']}" if ENV['BOSH_TARGET']
+target="#{target} -d #{ENV['BOSH_DEPLOYMENT']}" if ENV['BOSH_DEPLOYMENT']
+target="#{target} -u #{ENV['BOSH_USER']}" if ENV['BOSH_USER']
+target="#{target} -p #{ENV['BOSH_PASSWORD']}" if ENV['BOSH_PASSWORD']
+
 namespace :dev_release do
+	desc "Creates DEV release"
+	task :create do
+		puts "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
+		sh "bosh #{target} create release --force"
+	end
 	desc "Creates and uploads DEV release to currently targeted BOSH."
-	task :create_and_upload do
+	task :create_and_upload => :create do
 		puts "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-		sh "bosh create release --force"
-		puts "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-		sh "bosh -n upload release"
+		sh "bosh #{target} -n upload release"
 	end
 	desc "Creates, uploads and deploys DEV release to currently targeted BOSH deployment manifest"
 	task :create_and_upload_and_deploy => :create_and_upload  do
 		puts "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-="
-		sh "bosh -n deploy"
+		sh "bosh #{target} -n deploy"
 	end
 end
 


### PR DESCRIPTION
Enables a Docker based build server to create logsearch dev releases using a command like:

```
docker build -t $JOB_NAME $(pwd)

docker run -e BOSH_TARGET=https://xx.yy.zz.bb:25555 -e BOSH_USER=sudobot -e BOSH_PASSWORD=$SUDOBOT_BOSH_PASSWORD -v $(pwd):/workspace -t $JOB_NAME rake dev_release:create_and_upload_and_deploy
```
