### PR TITLE
Add support for logsearch-shipper

### DIFF
--- a/jobs/api/spec
+++ b/jobs/api/spec
@@ -10,6 +10,7 @@ templates:
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
+  logsearch/metric-collector/lag/collector: logsearch/metric-collector/lag/collector
 properties:
   api.elasticsearch_host:
     description: IP address and port of elasticsearch host to proxy requests for (eg, 127.0.0.1:9200)

--- a/jobs/api/templates/logsearch/metric-collector/lag/collector
+++ b/jobs/api/templates/logsearch/metric-collector/lag/collector
@@ -4,6 +4,8 @@ require 'json'
 require 'net/http'
 require 'uri'
 
+STDOUT.sync = true
+
 freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
 
 while true

--- a/jobs/api/templates/logsearch/metric-collector/lag/collector
+++ b/jobs/api/templates/logsearch/metric-collector/lag/collector
@@ -6,7 +6,7 @@ require 'uri'
 
 STDOUT.sync = true
 
-freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
+freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : nil
 
 while true
   ts = Time.now.utc
@@ -61,6 +61,8 @@ while true
 
   puts "logstash.search_lag #{[0, ts.to_i - body['aggregations']['max_timestamp']['value'].to_i / 1000].max} #{ts.to_i}"
 
+
+  exit if freq.nil?
 
   begin
     sleep(freq)

--- a/jobs/api/templates/logsearch/metric-collector/lag/collector
+++ b/jobs/api/templates/logsearch/metric-collector/lag/collector
@@ -1,0 +1,68 @@
+#!/var/vcap/bosh/bin/ruby
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
+
+while true
+  ts = Time.now.utc
+
+  uri = URI("http://localhost:9200/logstash-#{ts.strftime('%Y.%m.%d')}/_search")
+
+  res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+    http.request(Net::HTTP::Post.new(uri.request_uri), JSON.generate(
+      {
+        "query" => {
+          "filtered" => {
+            "query" => {
+              "bool" => {
+                "should" => [
+                  {
+                    "query_string" => {
+                      "query" => "*"
+                    }
+                  }
+                ]
+              }
+            },
+            "filter" => {
+              "bool" => {
+                "must" => [
+                  {
+                    "range" => {
+                      "@timestamp" => {
+                        "to" => ts.strftime('%Y-%m-%dT%H:%M:%S.999Z'),
+                        "from" => "2001-01-01T00:00:00.000Z"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "aggregations" => {
+          "max_timestamp" => {
+            "max" => {
+              "field" => "@timestamp"
+            }
+          }
+        },
+        "size" => 0
+      }
+    ))
+  }
+
+  body = JSON.parse(res.body)
+
+  puts "logstash.search_lag #{[0, ts.to_i - body['aggregations']['max_timestamp']['value'].to_i / 1000].max} #{ts.to_i}"
+
+
+  begin
+    sleep(freq)
+  rescue Interrupt => e
+    exit
+  end
+end

--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -14,6 +14,8 @@ templates:
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
+  logsearch/metric-collector/elasticsearch/collector: logsearch/metric-collector/elasticsearch/collector
+  logsearch/logs.yml: logsearch/logs.yml
 properties:
   elasticsearch.drain:
     description: Whether to use the built-in drain features to improve deployment reliability

--- a/jobs/elasticsearch/templates/logsearch/logs.yml
+++ b/jobs/elasticsearch/templates/logsearch/logs.yml
@@ -1,0 +1,4 @@
+files:
+  "elasticsearch/requests.log":
+    fields:
+      type: "elasticsearch_request"

--- a/jobs/elasticsearch/templates/logsearch/metric-collector/elasticsearch/collector
+++ b/jobs/elasticsearch/templates/logsearch/metric-collector/elasticsearch/collector
@@ -4,6 +4,8 @@ require 'json'
 require 'net/http'
 require 'uri'
 
+STDOUT.sync = true
+
 uri = URI('http://localhost:9200/_nodes/_local/stats/transport,http,process,jvm,indices?pretty')
 
 freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300

--- a/jobs/elasticsearch/templates/logsearch/metric-collector/elasticsearch/collector
+++ b/jobs/elasticsearch/templates/logsearch/metric-collector/elasticsearch/collector
@@ -6,9 +6,9 @@ require 'uri'
 
 STDOUT.sync = true
 
-uri = URI('http://localhost:9200/_nodes/_local/stats/transport,http,process,jvm,indices?pretty')
+freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : nil
 
-freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
+uri = URI('http://localhost:9200/_nodes/_local/stats/transport,http,process,jvm,indices?pretty')
 
 while true
   res = Net::HTTP.start(uri.hostname, uri.port) {|http|
@@ -141,6 +141,8 @@ while true
   puts "elasticsearch.http.current_open #{node_stats['http']['current_open']} #{ts}"
   puts "elasticsearch.http.total_opened #{node_stats['http']['total_opened']} #{ts}"
 
+
+  exit if freq.nil?
 
   begin
     sleep(freq)

--- a/jobs/elasticsearch/templates/logsearch/metric-collector/elasticsearch/collector
+++ b/jobs/elasticsearch/templates/logsearch/metric-collector/elasticsearch/collector
@@ -1,0 +1,148 @@
+#!/var/vcap/bosh/bin/ruby
+
+require 'json'
+require 'net/http'
+require 'uri'
+
+uri = URI('http://localhost:9200/_nodes/_local/stats/transport,http,process,jvm,indices?pretty')
+
+freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
+
+while true
+  res = Net::HTTP.start(uri.hostname, uri.port) {|http|
+    http.request(Net::HTTP::Get.new(uri.request_uri))
+  }
+
+  stats = JSON.parse(res.body)
+  node_name, node_stats = stats['nodes'].first
+
+  ts = node_stats['timestamp'].to_i / 1000
+
+  # indices
+
+  puts "elasticsearch.indices.docs.count #{node_stats['indices']['docs']['count']} #{ts}"
+  puts "elasticsearch.indices.docs.deleted #{node_stats['indices']['docs']['deleted']} #{ts}"
+
+  puts "elasticsearch.indices.store.size_in_bytes #{node_stats['indices']['store']['size_in_bytes']} #{ts}"
+  puts "elasticsearch.indices.store.throttle_time_in_millis #{node_stats['indices']['store']['throttle_time_in_millis']} #{ts}"
+
+  puts "elasticsearch.indices.indexing.index_total #{node_stats['indices']['indexing']['index_total']} #{ts}"
+  puts "elasticsearch.indices.indexing.index_time_in_millis #{node_stats['indices']['indexing']['index_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.indexing.index_current #{node_stats['indices']['indexing']['index_current']} #{ts}"
+  puts "elasticsearch.indices.indexing.delete_total #{node_stats['indices']['indexing']['delete_total']} #{ts}"
+  puts "elasticsearch.indices.indexing.delete_time_in_millis #{node_stats['indices']['indexing']['delete_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.indexing.delete_current #{node_stats['indices']['indexing']['delete_current']} #{ts}"
+
+  puts "elasticsearch.indices.get.total #{node_stats['indices']['get']['total']} #{ts}"
+  puts "elasticsearch.indices.get.time_in_millis #{node_stats['indices']['get']['time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.get.exists_total #{node_stats['indices']['get']['exists_total']} #{ts}"
+  puts "elasticsearch.indices.get.exists_time_in_millis #{node_stats['indices']['get']['exists_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.get.missing_total #{node_stats['indices']['get']['missing_total']} #{ts}"
+  puts "elasticsearch.indices.get.missing_time_in_millis #{node_stats['indices']['get']['missing_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.get.current #{node_stats['indices']['get']['current']} #{ts}"
+
+  puts "elasticsearch.indices.search.open_contexts #{node_stats['indices']['search']['open_contexts']} #{ts}"
+  puts "elasticsearch.indices.search.query_total #{node_stats['indices']['search']['query_total']} #{ts}"
+  puts "elasticsearch.indices.search.query_time_in_millis #{node_stats['indices']['search']['query_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.search.query_current #{node_stats['indices']['search']['query_current']} #{ts}"
+  puts "elasticsearch.indices.search.fetch_total #{node_stats['indices']['search']['fetch_total']} #{ts}"
+  puts "elasticsearch.indices.search.fetch_time_in_millis #{node_stats['indices']['search']['fetch_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.search.fetch_current #{node_stats['indices']['search']['fetch_current']} #{ts}"
+
+  puts "elasticsearch.indices.merges.current #{node_stats['indices']['merges']['current']} #{ts}"
+  puts "elasticsearch.indices.merges.current_docs #{node_stats['indices']['merges']['current_docs']} #{ts}"
+  puts "elasticsearch.indices.merges.current_size_in_bytes #{node_stats['indices']['merges']['current_size_in_bytes']} #{ts}"
+  puts "elasticsearch.indices.merges.total #{node_stats['indices']['merges']['total']} #{ts}"
+  puts "elasticsearch.indices.merges.total_time_in_millis #{node_stats['indices']['merges']['total_time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.merges.total_docs #{node_stats['indices']['merges']['total_docs']} #{ts}"
+  puts "elasticsearch.indices.merges.total_size_in_bytes #{node_stats['indices']['merges']['total_size_in_bytes']} #{ts}"
+
+  puts "elasticsearch.indices.refresh.total #{node_stats['indices']['refresh']['total']} #{ts}"
+  puts "elasticsearch.indices.refresh.total_time_in_millis #{node_stats['indices']['refresh']['total_time_in_millis']} #{ts}"
+
+  puts "elasticsearch.indices.flush.total #{node_stats['indices']['flush']['total']} #{ts}"
+  puts "elasticsearch.indices.flush.total_time_in_millis #{node_stats['indices']['flush']['total_time_in_millis']} #{ts}"
+
+  puts "elasticsearch.indices.warmer.current #{node_stats['indices']['warmer']['current']} #{ts}"
+  puts "elasticsearch.indices.warmer.total #{node_stats['indices']['warmer']['total']} #{ts}"
+  puts "elasticsearch.indices.warmer.total_time_in_millis #{node_stats['indices']['warmer']['total_time_in_millis']} #{ts}"
+
+  puts "elasticsearch.indices.filter_cache.memory_size_in_bytes #{node_stats['indices']['filter_cache']['memory_size_in_bytes']} #{ts}"
+  puts "elasticsearch.indices.filter_cache.evictions #{node_stats['indices']['filter_cache']['evictions']} #{ts}"
+
+  puts "elasticsearch.indices.id_cache.memory_size_in_bytes #{node_stats['indices']['id_cache']['memory_size_in_bytes']} #{ts}"
+
+  puts "elasticsearch.indices.fielddata.memory_size_in_bytes #{node_stats['indices']['fielddata']['memory_size_in_bytes']} #{ts}"
+  puts "elasticsearch.indices.fielddata.evictions #{node_stats['indices']['fielddata']['evictions']} #{ts}"
+
+  puts "elasticsearch.indices.percolate.total #{node_stats['indices']['percolate']['total']} #{ts}"
+  puts "elasticsearch.indices.percolate.time_in_millis #{node_stats['indices']['percolate']['time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.percolate.current #{node_stats['indices']['percolate']['current']} #{ts}"
+  puts "elasticsearch.indices.percolate.memory_size_in_bytes #{node_stats['indices']['percolate']['memory_size_in_bytes']} #{ts}"
+  puts "elasticsearch.indices.percolate.queries #{node_stats['indices']['percolate']['queries']} #{ts}"
+
+  puts "elasticsearch.indices.completion.size_in_bytes #{node_stats['indices']['completion']['size_in_bytes']} #{ts}"
+
+  puts "elasticsearch.indices.segments.count #{node_stats['indices']['segments']['count']} #{ts}"
+  puts "elasticsearch.indices.segments.memory_in_bytes #{node_stats['indices']['segments']['memory_in_bytes']} #{ts}"
+
+  puts "elasticsearch.indices.translog.operations #{node_stats['indices']['translog']['operations']} #{ts}"
+  puts "elasticsearch.indices.translog.size_in_bytes #{node_stats['indices']['translog']['size_in_bytes']} #{ts}"
+
+  puts "elasticsearch.indices.suggest.total #{node_stats['indices']['suggest']['total']} #{ts}"
+  puts "elasticsearch.indices.suggest.time_in_millis #{node_stats['indices']['suggest']['time_in_millis']} #{ts}"
+  puts "elasticsearch.indices.suggest.current #{node_stats['indices']['suggest']['current']} #{ts}"
+
+  # process
+
+  puts "elasticsearch.process.open_file_descriptors #{node_stats['process']['open_file_descriptors']} #{ts}"
+
+  puts "elasticsearch.process.cpu.percent #{node_stats['process']['cpu']['percent']} #{ts}"
+  puts "elasticsearch.process.cpu.sys_in_millis #{node_stats['process']['cpu']['sys_in_millis']} #{ts}"
+  puts "elasticsearch.process.cpu.user_in_millis #{node_stats['process']['cpu']['user_in_millis']} #{ts}"
+  puts "elasticsearch.process.cpu.total_in_millis #{node_stats['process']['cpu']['total_in_millis']} #{ts}"
+
+  puts "elasticsearch.process.mem.resident_in_bytes #{node_stats['process']['mem']['resident_in_bytes']} #{ts}"
+  puts "elasticsearch.process.mem.share_in_bytes #{node_stats['process']['mem']['share_in_bytes']} #{ts}"
+  puts "elasticsearch.process.mem.total_virtual_in_bytes #{node_stats['process']['mem']['total_virtual_in_bytes']} #{ts}"
+
+  # jvm
+
+  puts "elasticsearch.jvm.uptime_in_millis #{node_stats['jvm']['uptime_in_millis']} #{ts}"
+
+  puts "elasticsearch.jvm.mem.heap_used_in_bytes #{node_stats['jvm']['mem']['heap_used_in_bytes']} #{ts}"
+  puts "elasticsearch.jvm.mem.heap_used_percent #{node_stats['jvm']['mem']['heap_used_percent']} #{ts}"
+  puts "elasticsearch.jvm.mem.heap_committed_in_bytes #{node_stats['jvm']['mem']['heap_committed_in_bytes']} #{ts}"
+  puts "elasticsearch.jvm.mem.heap_max_in_bytes #{node_stats['jvm']['mem']['heap_max_in_bytes']} #{ts}"
+  puts "elasticsearch.jvm.mem.non_heap_used_in_bytes #{node_stats['jvm']['mem']['non_heap_used_in_bytes']} #{ts}"
+  puts "elasticsearch.jvm.mem.non_heap_committed_in_bytes #{node_stats['jvm']['mem']['non_heap_committed_in_bytes']} #{ts}"
+
+  puts "elasticsearch.jvm.threads.count #{node_stats['jvm']['threads']['count']} #{ts}"
+  puts "elasticsearch.jvm.threads.peak_count #{node_stats['jvm']['threads']['peak_count']} #{ts}"
+
+  puts "elasticsearch.jvm.gc.collectors.young.collection_count #{node_stats['jvm']['gc']['collectors']['young']['collection_count']} #{ts}"
+  puts "elasticsearch.jvm.gc.collectors.young.collection_time_in_millis #{node_stats['jvm']['gc']['collectors']['young']['collection_time_in_millis']} #{ts}"
+
+  puts "elasticsearch.jvm.gc.collectors.old.collection_count #{node_stats['jvm']['gc']['collectors']['old']['collection_count']} #{ts}"
+  puts "elasticsearch.jvm.gc.collectors.old.collection_time_in_millis #{node_stats['jvm']['gc']['collectors']['old']['collection_time_in_millis']} #{ts}"
+
+  # transport
+
+  puts "elasticsearch.transport.server_open #{node_stats['transport']['server_open']} #{ts}"
+  puts "elasticsearch.transport.rx_count #{node_stats['transport']['rx_count']} #{ts}"
+  puts "elasticsearch.transport.rx_size_in_bytes #{node_stats['transport']['rx_size_in_bytes']} #{ts}"
+  puts "elasticsearch.transport.tx_count #{node_stats['transport']['tx_count']} #{ts}"
+  puts "elasticsearch.transport.tx_size_in_bytes #{node_stats['transport']['tx_size_in_bytes']} #{ts}"
+
+  # http
+
+  puts "elasticsearch.http.current_open #{node_stats['http']['current_open']} #{ts}"
+  puts "elasticsearch.http.total_opened #{node_stats['http']['total_opened']} #{ts}"
+
+
+  begin
+    sleep(freq)
+  rescue Interrupt => e
+    exit
+  end
+end

--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -9,6 +9,7 @@ templates:
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   config/redis.conf.erb: config/redis.conf
+  logsearch/metric-collector/redis/collector: logsearch/metric-collector/redis/collector
 properties:
   redis.port: 
     description: Redis port of queue

--- a/jobs/queue/templates/logsearch/metric-collector/redis/collector
+++ b/jobs/queue/templates/logsearch/metric-collector/redis/collector
@@ -2,6 +2,8 @@
 
 require 'socket'
 
+STDOUT.sync = true
+
 freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
 useful_info = [
   'uptime_in_seconds',

--- a/jobs/queue/templates/logsearch/metric-collector/redis/collector
+++ b/jobs/queue/templates/logsearch/metric-collector/redis/collector
@@ -1,0 +1,53 @@
+#!/var/vcap/bosh/bin/ruby
+
+require 'socket'
+
+freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
+useful_info = [
+  'uptime_in_seconds',
+  'connected_clients',
+  'connected_slaves',
+  'blocked_clients',
+  'evicted_keys',
+  'used_memory',
+  'changes_since_last_save',
+  'total_connections_received',
+  'total_commands_processed',
+]
+
+while true
+  ts = Time.now.utc.to_i
+
+  sh = TCPSocket.new('127.0.0.1', 6379)
+
+  sh.write("llen logstash\r\n")
+
+  # :{size}
+  puts "logstash.queue_size #{sh.gets()[1..-1].chop} #{ts}"
+
+
+  sh.write("info\r\n")
+
+  # ${length}
+  len = sh.gets()[1..-1].chop.to_i
+  result = ""
+
+  while result.length < len
+    result << sh.gets
+  end
+
+  result.scan /^[a-zA-Z0-9_]+:.*$/ do | match |
+    k, v = match.chop.split(':')
+
+    puts "redis.#{k} #{v} #{ts}" if useful_info.include? k
+  end
+
+  sh.close
+
+
+  begin
+    sleep(freq)
+  rescue Interrupt => e
+    exit
+  end
+end

--- a/jobs/queue/templates/logsearch/metric-collector/redis/collector
+++ b/jobs/queue/templates/logsearch/metric-collector/redis/collector
@@ -4,7 +4,8 @@ require 'socket'
 
 STDOUT.sync = true
 
-freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : 300
+freq = ENV.has_key?('METRIC_FREQUENCY') ? ENV['METRIC_FREQUENCY'].to_i : nil
+
 useful_info = [
   'uptime_in_seconds',
   'connected_clients',
@@ -46,6 +47,8 @@ while true
 
   sh.close
 
+
+  exit if freq.nil?
 
   begin
     sleep(freq)

--- a/share/kibana-dashboards/logsearch-overview.json
+++ b/share/kibana-dashboards/logsearch-overview.json
@@ -1,0 +1,810 @@
+{
+  "title": "{{ARGS.director||'????'}}/{{ARGS.deployment||'????'}}",
+  "services": {
+    "query": {
+      "list": {
+        "0": {
+          "query": "*",
+          "alias": "",
+          "color": "#7EB26D",
+          "id": 0,
+          "pin": false,
+          "type": "lucene",
+          "enable": true
+        },
+        "1": {
+          "id": 1,
+          "color": "#447EBC",
+          "alias": "Messages",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"logstash.queue_size\""
+        },
+        "2": {
+          "id": 2,
+          "color": "#EF843C",
+          "alias": "Workers",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"redis.connected_clients\""
+        },
+        "3": {
+          "id": 3,
+          "color": "#7EB26D",
+          "alias": "Commands",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"redis.total_commands_processed\""
+        },
+        "4": {
+          "id": 4,
+          "color": "#E5AC0E",
+          "alias": "Total",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"elasticsearch.indices.indexing.index_total\""
+        },
+        "5": {
+          "id": 5,
+          "color": "#64B0C8",
+          "alias": "Time",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"elasticsearch.indices.indexing.index_time_in_millis\""
+        },
+        "6": {
+          "id": 6,
+          "color": "#E5AC0E",
+          "alias": "Total",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"elasticsearch.indices.search.query_total\""
+        },
+        "7": {
+          "id": 7,
+          "color": "#64B0C8",
+          "alias": "Time",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"elasticsearch.indices.search.query_time_in_millis\""
+        },
+        "8": {
+          "id": 8,
+          "color": "#629E51",
+          "alias": "Lag",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"metric\" AND name:\"logstash.search_lag\""
+        },
+        "9": {
+          "id": 9,
+          "color": "#7EB26D",
+          "alias": "Non-metrics",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "NOT _type:\"metric\""
+        },
+        "10": {
+          "id": 10,
+          "color": "#7EB26D",
+          "alias": "Elasticsearch Requests",
+          "pin": true,
+          "type": "lucene",
+          "enable": true,
+          "query": "_type:\"elasticsearch_request\""
+        }
+      },
+      "ids": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10
+      ]
+    },
+    "filter": {
+      "list": {
+        "0": {
+          "type": "time",
+          "field": "@timestamp",
+          "from": "now-1h",
+          "to": "now",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 0
+        },
+        "1": {
+          "type": "field",
+          "query": "@source.bosh_director:\"{{ARGS.director||'????'}}\"",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 1
+        },
+        "2": {
+          "type": "field",
+          "query": "@source.bosh_deployment:\"{{ARGS.deployment||'????'}}\"",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 2
+        }
+      },
+      "ids": [
+        0,
+        1,
+        2
+      ]
+    }
+  },
+  "rows": [
+    {
+      "title": "Graph",
+      "height": "200px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              1
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "resolution": 60,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 2,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Queue Size"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              3
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "resolution": 60,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 2,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": true,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Queue Processing"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              2
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "resolution": 60,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 3,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Queue Workers"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Elasticsearch",
+      "height": "200px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              8
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "resolution": 60,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 3,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Lag"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              4,
+              5
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "resolution": 60,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": true,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Indexing"
+        },
+        {
+          "span": 4,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "value",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "none",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              6,
+              7
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": true,
+          "resolution": 60,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 2,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": true,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": true,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Searching"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Elasticsearch Requests",
+      "height": "350px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "type": "table",
+          "loadingEditor": false,
+          "size": 50,
+          "pages": 10,
+          "offset": 0,
+          "sort": [
+            "_score",
+            "desc"
+          ],
+          "overflow": "min-height",
+          "fields": [
+            "@timestamp",
+            "remoteaddr",
+            "@source.bosh_job",
+            "path",
+            "size",
+            "duration",
+            "status",
+            "code"
+          ],
+          "highlight": [],
+          "sortable": true,
+          "header": true,
+          "paging": true,
+          "field_list": false,
+          "all_fields": false,
+          "trimFactor": 300,
+          "localTime": true,
+          "timeField": "@timestamp",
+          "spyable": true,
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              10
+            ]
+          },
+          "style": {
+            "font-size": "9pt"
+          },
+          "normTimes": true,
+          "title": "Elasticsearch Requests"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "All Events",
+      "height": "350px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "title": "All Events",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "group": [
+            "default"
+          ],
+          "type": "table",
+          "size": 100,
+          "pages": 5,
+          "offset": 0,
+          "sort": [
+            "@timestamp",
+            "desc"
+          ],
+          "style": {
+            "font-size": "9pt"
+          },
+          "overflow": "min-height",
+          "fields": [
+            "@timestamp",
+            "@source.bosh_job",
+            "@source.bosh_template",
+            "_type"
+          ],
+          "localTime": true,
+          "timeField": "@timestamp",
+          "highlight": [],
+          "sortable": true,
+          "header": true,
+          "paging": true,
+          "spyable": true,
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              9
+            ]
+          },
+          "field_list": false,
+          "status": "Stable",
+          "trimFactor": 300,
+          "normTimes": true,
+          "all_fields": false
+        }
+      ],
+      "notice": false
+    }
+  ],
+  "editable": true,
+  "failover": false,
+  "index": {
+    "interval": "day",
+    "pattern": "[logstash-]YYYY.MM.DD",
+    "default": "NO_TIME_FILTER_OR_INDEX_PATTERN_NOT_MATCHED",
+    "warm_fields": true
+  },
+  "style": "dark",
+  "panel_hints": true,
+  "pulldowns": [
+    {
+      "type": "query",
+      "collapse": true,
+      "notice": false,
+      "query": "*",
+      "pinned": true,
+      "history": [
+        "_type:\"metric\" AND name:\"logstash.queue_size\"",
+        "*"
+      ],
+      "remember": 10,
+      "enable": false
+    },
+    {
+      "type": "filtering",
+      "collapse": true,
+      "notice": false,
+      "enable": false
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "timefield": "@timestamp",
+      "now": true,
+      "filter_id": 0,
+      "enable": true
+    }
+  ],
+  "loader": {
+    "save_gist": false,
+    "save_elasticsearch": true,
+    "save_local": true,
+    "save_default": true,
+    "save_temp": true,
+    "save_temp_ttl_enable": true,
+    "save_temp_ttl": "30d",
+    "load_gist": true,
+    "load_elasticsearch": true,
+    "load_elasticsearch_size": 20,
+    "load_local": true,
+    "hide": false
+  },
+  "refresh": "1m"
+}


### PR DESCRIPTION
This adds metric-collectors and log configs for the [logsearch-shipper-boshrelease](https://github.com/logsearch/logsearch-shipper-boshrelease). We've been using it for well over a month now... I didn't realize this was still on a separate branch.
