### PR TITLE
Add Initial Archiver Functionality

### DIFF
--- a/jobs/archiver/monit
+++ b/jobs/archiver/monit
@@ -1,0 +1,5 @@
+check process archiver
+  with pidfile /var/vcap/sys/run/archiver/logstash.pid
+  start program "/var/vcap/jobs/archiver/bin/logstash.process start"
+  stop program "/var/vcap/jobs/archiver/bin/logstash.process stop"
+  group vcap

--- a/jobs/archiver/spec
+++ b/jobs/archiver/spec
@@ -28,3 +28,6 @@ properties:
   archiver.data_dir:
     default: "/var/vcap/store/archiver"
     description: "Directory for dumping log files"
+  archiver.cron_schedule:
+    default: "*/30 * * * *"
+    description: "Schedule for pausing the archiver to upload log files"

--- a/jobs/archiver/spec
+++ b/jobs/archiver/spec
@@ -20,6 +20,10 @@ properties:
     description: "S3 Bucket"
   archiver.s3.prefix:
     description: "S3 Prefix"
+    default: ""
+  archiver.s3.endpoint:
+    description: "S3 Endpoint"
+    default: "s3.amazonaws.com"
   archiver.s3.access_key_id:
     description: "S3 Access Key ID"
   archiver.s3.secret_access_key:

--- a/jobs/archiver/spec
+++ b/jobs/archiver/spec
@@ -31,3 +31,6 @@ properties:
   archiver.cron_schedule:
     default: "*/30 * * * *"
     description: "Schedule for pausing the archiver to upload log files"
+  archiver.workers:
+    default: "auto"
+    description: "The number of worker threads that logstash should use (default: auto = one per CPU)"

--- a/jobs/archiver/spec
+++ b/jobs/archiver/spec
@@ -1,0 +1,30 @@
+---
+name: archiver
+packages:
+- logstash
+templates:
+  bin/logstash.process.erb: bin/logstash.process
+  bin/s3upload.cron.erb: bin/s3upload.cron
+  config/logstash.conf.erb: config/logstash.conf
+properties:
+  redis.host:
+    description: Redis host of queue
+  redis.port:
+    description: Redis port of queue
+    default: 6379
+  redis.key:
+    description: Name of queue to pull messages from
+    default: logstash
+
+  archiver.s3.bucket:
+    description: "S3 Bucket"
+  archiver.s3.prefix:
+    description: "S3 Prefix"
+  archiver.s3.access_key_id:
+    description: "S3 Access Key ID"
+  archiver.s3.secret_access_key:
+    description: "S3 Secret Access Key"
+
+  archiver.data_dir:
+    default: "/var/vcap/store/archiver"
+    description: "Directory for dumping log files"

--- a/jobs/archiver/templates/bin/logstash.process.erb
+++ b/jobs/archiver/templates/bin/logstash.process.erb
@@ -19,6 +19,13 @@ chown vcap:vcap "$DATADIR"
 exec >> /var/vcap/sys/log/archiver/logstash.control.log
 exec 2>&1
 
+<% if 'auto' == p('archiver.workers') %>
+# 1 logstash worker / CPU core
+export LOGSTASH_WORKERS=`grep -c ^processor /proc/cpuinfo`
+<% else %>
+export LOGSTASH_WORKERS=<%= p('archiver.workers') %>
+<% end %>
+
 
 case $1 in
 
@@ -33,6 +40,7 @@ case $1 in
         exec /var/vcap/packages/logstash/logstash/bin/logstash \
         agent \
         --config /var/vcap/jobs/archiver/config/logstash.conf \
+        -w ${LOGSTASH_WORKERS} \
         >> \"$LOGDIR/logstash.stdout.log\" \
         2>> \"$LOGDIR/logstash.stderr.log\" \
       "

--- a/jobs/archiver/templates/bin/logstash.process.erb
+++ b/jobs/archiver/templates/bin/logstash.process.erb
@@ -37,7 +37,7 @@ case $1 in
         2>> \"$LOGDIR/logstash.stderr.log\" \
       "
 
-    echo "*/30 * * * * root bash -c 'exec /var/vcap/jobs/archiver/bin/s3upload.cron >> $LOGDIR/s3upload.stdout.log 2>> $LOGDIR/s3upload.stderr.log'" > /etc/cron.d/25-vcap-archiver
+    echo "<%= p('archiver.cron_schedule') %> root bash -c 'exec /var/vcap/jobs/archiver/bin/s3upload.cron >> $LOGDIR/s3upload.stdout.log 2>> $LOGDIR/s3upload.stderr.log'" > /etc/cron.d/25-vcap-archiver
     touch /etc/cron.d
 
     ;;

--- a/jobs/archiver/templates/bin/logstash.process.erb
+++ b/jobs/archiver/templates/bin/logstash.process.erb
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+set -u
+
+PIDFILE=/var/vcap/sys/run/archiver/logstash.pid
+LOGDIR=/var/vcap/sys/log/archiver
+DATADIR="<%= p('archiver.data_dir') %>"
+
+mkdir -p `dirname "$PIDFILE"`
+chown vcap:vcap `dirname "$PIDFILE"`
+
+mkdir -p "$LOGDIR"
+chown vcap:vcap "$LOGDIR"
+
+mkdir -p "$DATADIR"
+chown vcap:vcap "$DATADIR"
+
+exec >> /var/vcap/sys/log/archiver/logstash.control.log
+exec 2>&1
+
+
+case $1 in
+
+  start)
+    /sbin/start-stop-daemon \
+      --background \
+      --pidfile $PIDFILE \
+      --exec /bin/bash \
+      --make-pidfile \
+      --start \
+      -- -c "JAVA_HOME=/var/vcap/packages/java7 \
+        exec /var/vcap/packages/logstash/logstash/bin/logstash \
+        agent \
+        --config /var/vcap/jobs/archiver/config/logstash.conf \
+        >> \"$LOGDIR/logstash.stdout.log\" \
+        2>> \"$LOGDIR/logstash.stderr.log\" \
+      "
+
+    echo "*/30 * * * * root bash -c 'exec /var/vcap/jobs/archiver/bin/s3upload.cron >> $LOGDIR/s3upload.stdout.log 2>> $LOGDIR/s3upload.stderr.log'" > /etc/cron.d/25-vcap-archiver
+    touch /etc/cron.d
+
+    ;;
+
+  stop)
+    rm /etc/cron.d/25-vcap-archiver
+    touch /etc/cron.d
+
+    /sbin/start-stop-daemon \
+      --pidfile $PIDFILE \
+      --signal INT \
+      --oknodo \
+      --stop \
+      --retry 15
+
+    ;;
+
+  *)
+    echo "Usage: control {start|stop}" >&2
+
+    exit 1
+
+    ;;
+
+esac

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -54,6 +54,7 @@ for FILE in $( ls *.log ) ; do
     echo "compressed ${FILE}"
 done
 
+EXIT_CODE=0
 
 for FILE in $( ls *.xz ) ; do
     echo "uploading ${FILE}"
@@ -64,7 +65,8 @@ for FILE in $( ls *.xz ) ; do
     S3GO_MIME="application/x-gzip"
     S3GO_SIGNATURE=$( echo -en "PUT\n${S3GO_MD5}\n${S3GO_MIME}\n${S3GO_NOW}\n${S3GO_ACL}\n/${S3_BUCKET}/${S3_PREFIX}${FILE}" | openssl sha1 -hmac "${S3_SECRET_ACCESS_KEY}" -binary | openssl enc -e -base64 )
 
-    curl \
+    R1=$( curl \
+        -s \
         -X PUT \
         -T "$FILE" \
         -H "$S3GO_ACL" \
@@ -72,15 +74,25 @@ for FILE in $( ls *.xz ) ; do
         -H "Date: $S3GO_NOW" \
         -H "Content-Type: application/x-gzip" \
         -H "Authorization: AWS ${S3_ACCESS_KEY_ID}:${S3GO_SIGNATURE}" \
-        "https://${S3_BUCKET}.${S3_ENDPOINT}/${S3_PREFIX}${FILE}"
+        "https://${S3_BUCKET}.${S3_ENDPOINT}/${S3_PREFIX}${FILE}" \
+        2>&1 \
+    )
 
-    echo "uploaded ${FILE}"
+    if echo "$R1" | grep "<Error>" > /dev/null 2>&1 ; then
+        echo "FAILED uploading ${FILE}"
+        echo "${R1}"
+
+        EXIT_CODE=1
+    else
+        echo $(date) "uploaded ${FILE}"
 
 
-    echo "removing ${FILE}"
+        echo $(date) "removing ${FILE}"
 
-    rm "${FILE}"
+        rm "${FILE}"
 
-    echo "removed ${FILE}"
+        echo $(date) "removed ${FILE}"
+    fi
 done
 
+exit $EXIT_CODE

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -e
+set -u
+
+S3_BUCKET="<%= p('archiver.s3.bucket') %>"
+S3_PREFIX="<%= p('archiver.s3.prefix') %>"
+S3_ACCESS_KEY_ID="<%= p('archiver.s3.access_key_id') %>"
+S3_SECRET_ACCESS_KEY="<%= p('archiver.s3.secret_access_key') %>"
+
+cd <%= p('archiver.data_dir') %>
+
+
+echo "stopping service"
+
+/var/vcap/bosh/bin/monit stop archiver
+
+while kill -0 $( cat /var/vcap/sys/run/archiver/logstash.pid ) >/dev/null 2>&1 ; do
+  sleep 2
+done
+
+echo "stopped service"
+
+
+for FILE in $(ls *.log) ; do
+    S3GO_FILE="${FILE}.`date +%Y%m%d%H%M%S`.tar.gz"
+
+
+    echo "compressing ${FILE}"
+
+    tar -czf "${S3GO_FILE}" "${FILE}"
+
+    echo "compressed ${FILE}"
+
+
+    echo "uploading ${S3GO_FILE}"
+
+    S3GO_NOW=$( date -R )
+    S3GO_MD5=$( openssl dgst -md5 -binary "${S3GO_FILE}" | openssl enc -e -base64 )
+    S3GO_ACL="x-amz-acl:private"
+    S3GO_MIME="application/x-gzip"
+    S3GO_SIGNATURE=$( echo -en "PUT\n${S3GO_MD5}\n${S3GO_MIME}\n${S3GO_NOW}\n${S3GO_ACL}\n/${S3_BUCKET}/${S3_PREFIX}${S3GO_FILE}" | openssl sha1 -hmac "${S3_SECRET_ACCESS_KEY}" -binary | openssl enc -e -base64 )
+
+    curl \
+        -X PUT \
+        -T "$S3GO_FILE" \
+        -H "$S3GO_ACL" \
+        -H "Content-MD5: ${S3GO_MD5}" \
+        -H "Date: $S3GO_NOW" \
+        -H "Content-Type: application/x-gzip" \
+        -H "Authorization: AWS ${S3_ACCESS_KEY_ID}:${S3GO_SIGNATURE}" \
+        "https://${S3_BUCKET}.s3.amazonaws.com/${S3_PREFIX}${S3GO_FILE}"
+
+    echo "uploaded ${S3GO_FILE}"
+
+
+    echo "removing ${S3GO_FILE}"
+
+    rm "${S3GO_FILE}"
+
+    echo "removed ${S3GO_FILE}"
+
+
+    echo "removing ${FILE}"
+
+    rm "${FILE}"
+
+    echo "removed ${FILE}"
+done
+
+
+echo "starting service"
+
+/var/vcap/bosh/bin/monit start archiver
+
+echo "started service"

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -3,6 +3,7 @@
 set -e
 set -u
 
+S3_ENDPOINT="<%= p('archiver.s3.endpoint') %>"
 S3_BUCKET="<%= p('archiver.s3.bucket') %>"
 S3_PREFIX="<%= p('archiver.s3.prefix') %>"
 S3_ACCESS_KEY_ID="<%= p('archiver.s3.access_key_id') %>"
@@ -71,7 +72,7 @@ for FILE in $( ls *.xz ) ; do
         -H "Date: $S3GO_NOW" \
         -H "Content-Type: application/x-gzip" \
         -H "Authorization: AWS ${S3_ACCESS_KEY_ID}:${S3GO_SIGNATURE}" \
-        "https://${S3_BUCKET}.s3.amazonaws.com/${S3_PREFIX}${FILE}"
+        "https://${S3_BUCKET}.${S3_ENDPOINT}/${S3_PREFIX}${FILE}"
 
     echo "uploaded ${FILE}"
 

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -17,7 +17,7 @@ echo "stopping service"
 
 /var/vcap/bosh/bin/monit stop archiver
 
-while kill -0 $( cat /var/vcap/sys/run/archiver/logstash.pid ) >/dev/null 2>&1 ; do
+while ! /var/vcap/bosh/bin/monit summary | grep archiver | grep 'not monitored' | grep -v 'pending' >/dev/null 2>&1 ; do
   sleep 2
 done
 

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -23,7 +23,7 @@ echo "stopped service"
 
 
 for FILE in $(ls *.log) ; do
-    S3GO_FILE="${FILE}.`date +%Y%m%d%H%M%S`.tar.gz"
+    S3GO_FILE="${FILE}.<%= name %>-<%= index %>-`date +%Y%m%d%H%M%S`.tar.gz"
 
 
     echo "compressing ${FILE}"

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -10,6 +10,8 @@ S3_SECRET_ACCESS_KEY="<%= p('archiver.s3.secret_access_key') %>"
 
 cd <%= p('archiver.data_dir') %>
 
+mkdir -p s3upload
+
 
 echo "stopping service"
 
@@ -22,43 +24,56 @@ done
 echo "stopped service"
 
 
-for FILE in $(ls *.log) ; do
-    S3GO_FILE="${FILE}.<%= name %>-<%= index %>-`date +%Y%m%d%H%M%S`.tar.gz"
+for FILE in $( ls *.log ) ; do
+    BASENAME=$( echo "${FILE}" | sed 's/\.log$//' )
+    DESTFILE="${BASENAME}.<%= name %>-<%= index %>-`date +%Y%m%d%H%M%S`.log"
+
+    echo "moving ${FILE} -> s3upload/${DESTFILE}"
+
+    mv "${FILE}" "s3upload/${DESTFILE}"
+
+    echo "moved ${FILE}"
+done
 
 
-    echo "compressing ${FILE}"
+echo "starting service"
 
-    tar -czf "${S3GO_FILE}" "${FILE}"
+/var/vcap/bosh/bin/monit start archiver
+
+echo "started service"
+
+
+cd s3upload
+
+for FILE in $( ls *.log ) ; do
+    echo "compressing ${FILE} -> ${FILE}.xz"
+
+    xz --compress "${FILE}"
 
     echo "compressed ${FILE}"
+done
 
 
-    echo "uploading ${S3GO_FILE}"
+for FILE in $( ls *.xz ) ; do
+    echo "uploading ${FILE}"
 
     S3GO_NOW=$( date -R )
-    S3GO_MD5=$( openssl dgst -md5 -binary "${S3GO_FILE}" | openssl enc -e -base64 )
+    S3GO_MD5=$( openssl dgst -md5 -binary "${FILE}" | openssl enc -e -base64 )
     S3GO_ACL="x-amz-acl:private"
     S3GO_MIME="application/x-gzip"
-    S3GO_SIGNATURE=$( echo -en "PUT\n${S3GO_MD5}\n${S3GO_MIME}\n${S3GO_NOW}\n${S3GO_ACL}\n/${S3_BUCKET}/${S3_PREFIX}${S3GO_FILE}" | openssl sha1 -hmac "${S3_SECRET_ACCESS_KEY}" -binary | openssl enc -e -base64 )
+    S3GO_SIGNATURE=$( echo -en "PUT\n${S3GO_MD5}\n${S3GO_MIME}\n${S3GO_NOW}\n${S3GO_ACL}\n/${S3_BUCKET}/${S3_PREFIX}${FILE}" | openssl sha1 -hmac "${S3_SECRET_ACCESS_KEY}" -binary | openssl enc -e -base64 )
 
     curl \
         -X PUT \
-        -T "$S3GO_FILE" \
+        -T "$FILE" \
         -H "$S3GO_ACL" \
         -H "Content-MD5: ${S3GO_MD5}" \
         -H "Date: $S3GO_NOW" \
         -H "Content-Type: application/x-gzip" \
         -H "Authorization: AWS ${S3_ACCESS_KEY_ID}:${S3GO_SIGNATURE}" \
-        "https://${S3_BUCKET}.s3.amazonaws.com/${S3_PREFIX}${S3GO_FILE}"
+        "https://${S3_BUCKET}.s3.amazonaws.com/${S3_PREFIX}${FILE}"
 
-    echo "uploaded ${S3GO_FILE}"
-
-
-    echo "removing ${S3GO_FILE}"
-
-    rm "${S3GO_FILE}"
-
-    echo "removed ${S3GO_FILE}"
+    echo "uploaded ${FILE}"
 
 
     echo "removing ${FILE}"
@@ -68,9 +83,3 @@ for FILE in $(ls *.log) ; do
     echo "removed ${FILE}"
 done
 
-
-echo "starting service"
-
-/var/vcap/bosh/bin/monit start archiver
-
-echo "started service"

--- a/jobs/archiver/templates/bin/s3upload.cron.erb
+++ b/jobs/archiver/templates/bin/s3upload.cron.erb
@@ -27,7 +27,7 @@ echo "stopped service"
 
 for FILE in $( ls *.log ) ; do
     BASENAME=$( echo "${FILE}" | sed 's/\.log$//' )
-    DESTFILE="${BASENAME}.<%= name %>-<%= index %>-`date +%Y%m%d%H%M%S`.log"
+    DESTFILE="${BASENAME}.`date +%Y%m%d%H%M%S`-<%= name %>-<%= index %>.log"
 
     echo "moving ${FILE} -> s3upload/${DESTFILE}"
 

--- a/jobs/archiver/templates/config/logstash.conf.erb
+++ b/jobs/archiver/templates/config/logstash.conf.erb
@@ -1,0 +1,16 @@
+input {
+    redis {
+        host => "<%= p("redis.host") %>"
+        port => "<%= p("redis.port") %>"
+        type => "redis-input"
+        data_type => "list"
+        key => "<%= p("redis.key") %>_archiver"
+        threads => 8
+    }
+}
+
+output {
+    file {
+        path => '<%= p('archiver.data_dir') %>/%{+YYYYMMddHH}.log'
+    }
+}

--- a/jobs/ingestor_lumberjack/spec
+++ b/jobs/ingestor_lumberjack/spec
@@ -43,3 +43,5 @@ properties:
     description: Name of queue to pull messages from
     default: logstash
 
+  archiver.enabled:
+    default: false

--- a/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
+++ b/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
@@ -34,4 +34,15 @@ output {
 		batch => true
 		batch_events => 50
 	}
+
+	<% if p('archiver.enabled') %>
+		redis {
+			host => "<%= p("redis.host") %>"
+			port => "<%= p("redis.port") %>"
+			data_type => "list"
+			key => "<%= p("redis.key") %>_archiver"
+			batch => true
+			batch_events => 50
+		}
+	<% end %>
 }

--- a/jobs/ingestor_relp/spec
+++ b/jobs/ingestor_relp/spec
@@ -36,3 +36,5 @@ properties:
     description: Name of queue to pull messages from
     default: logstash
 
+  archiver.enabled:
+    default: false

--- a/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
+++ b/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
@@ -21,4 +21,15 @@ output {
 		batch => true
 		batch_events => 50
 	}
+
+	<% if p('archiver.enabled') %>
+		redis {
+			host => "<%= p("redis.host") %>"
+			port => "<%= p("redis.port") %>"
+			data_type => "list"
+			key => "<%= p("redis.key") %>_archiver"
+			batch => true
+			batch_events => 50
+		}
+	<% end %>
 }

--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -46,3 +46,5 @@ properties:
     description: Name of queue to pull messages from
     default: logstash
 
+  archiver.enabled:
+    default: false

--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -46,4 +46,15 @@ output {
 		batch => true
 		batch_events => 50
 	}
+
+	<% if p('archiver.enabled') %>
+		redis {
+			host => "<%= p("redis.host") %>"
+			port => "<%= p("redis.port") %>"
+			data_type => "list"
+			key => "<%= p("redis.key") %>_archiver"
+			batch => true
+			batch_events => 50
+		}
+	<% end %>
 }

--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -14,4 +14,6 @@ properties:
   redis.port: 
     description: Redis port of queue
     default: 6379
-
+  redis.key:
+    description: Name of queue to pull messages from
+    default: logstash

--- a/jobs/queue/templates/logsearch/metric-collector/redis/collector
+++ b/jobs/queue/templates/logsearch/metric-collector/redis/collector
@@ -24,13 +24,13 @@ while true
   sh = TCPSocket.new('127.0.0.1', 6379)
 
 
-  sh.write("llen logstash\r\n")
+  sh.write("llen <%= p('redis.key') %>\r\n")
 
   # :{size}
   puts "logstash.queue_size #{sh.gets()[1..-1].chop} #{ts}"
 
 
-  sh.write("llen logstash_archiver\r\n")
+  sh.write("llen <%= p('redis.key') %>_archiver\r\n")
 
   # :{size}
   puts "logstash.archiver_queue_size #{sh.gets()[1..-1].chop} #{ts}"

--- a/jobs/queue/templates/logsearch/metric-collector/redis/collector
+++ b/jobs/queue/templates/logsearch/metric-collector/redis/collector
@@ -23,10 +23,17 @@ while true
 
   sh = TCPSocket.new('127.0.0.1', 6379)
 
+
   sh.write("llen logstash\r\n")
 
   # :{size}
   puts "logstash.queue_size #{sh.gets()[1..-1].chop} #{ts}"
+
+
+  sh.write("llen logstash_archiver\r\n")
+
+  # :{size}
+  puts "logstash.archiver_queue_size #{sh.gets()[1..-1].chop} #{ts}"
 
 
   sh.write("info\r\n")


### PR DESCRIPTION
This adds an `archiver` job which can regularly push a copy of all log messages into S3. To enable, review and configure the `archiver.*` properties, install the job, and set `archiver.enabled` to `true` for the relevant ingestor(s). In the future, some restore scripts and documentation will accompany the job.
