### PR TITLE
Add extra event metadata

### DIFF
--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -1,19 +1,19 @@
 ---
 name: logsearch
-director_uuid: c5f8d0da-f8ac-4918-a1a3-0a846fb97d09
+director_uuid: 4e46066f-e59b-493e-b775-accc1a7bc6e2
 
 releases:
 - name: logsearch
   version: latest
 
 compilation:
-  workers: 3
+  workers: 2
   network: default
   reuse_compilation_vms: true
   cloud_properties: {}
 
 update:
-  serial: false #Deploy jobs in parallel
+  serial: true
   canaries: 1
   canary_watch_time: 30000
   update_watch_time: 30000

--- a/jobs/ingestor_lumberjack/spec
+++ b/jobs/ingestor_lumberjack/spec
@@ -13,6 +13,10 @@ templates:
   config/lumberjack.crt.erb: config/lumberjack.crt
   config/lumberjack.key.erb: config/lumberjack.key
 properties:
+  logstash.metadata_level:
+    description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
+    default: "NONE"
+
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
+++ b/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
@@ -14,12 +14,12 @@ filter {
 		add_field => [ "@source.offset", "%{offset}" ]
 		remove_field => [ "host", "file", "offset" ]
 
-		add_field => [ "@ingestor.service", "lumberjack" ]
-		add_field => [ "@ingestor.job", "<%= name %>/<%= index %>" ]
+		add_field => [ "@ingestor[service]", "lumberjack" ]
+		add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
 	}
 
 	ruby {
-		code => "event['@ingestor.timestamp'] = Time.now.iso8601(3)"
+		code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
 	}
 }
 				

--- a/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
+++ b/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
@@ -1,6 +1,5 @@
 input {
 	lumberjack {
-		add_field => [ "_logstash_input", "lumberjack" ]
 		host => "0.0.0.0"
 		port => "<%= p("logstash_ingestor.lumberjack.port") %>"
 		ssl_certificate => "/var/vcap/jobs/ingestor_lumberjack/config/lumberjack.crt"
@@ -9,13 +8,18 @@ input {
 }
 
 filter {
-	if [_logstash_input] == "lumberjack" {
-		mutate {
-			add_field => [ "@source.host", "%{host}" ]
-			add_field => [ "@source.path", "%{file}" ]
-			add_field => [ "@source.offset", "%{offset}" ]
-			remove_field => [ "host", "file", "offset", "_logstash_input" ]
-		}
+	mutate {
+		add_field => [ "@source.host", "%{host}" ]
+		add_field => [ "@source.path", "%{file}" ]
+		add_field => [ "@source.offset", "%{offset}" ]
+		remove_field => [ "host", "file", "offset" ]
+
+		add_field => [ "@ingestor.service", "lumberjack" ]
+		add_field => [ "@ingestor.job", "<%= name %>/<%= index %>" ]
+	}
+
+	ruby {
+		code => "event['@ingestor.timestamp'] = Time.now.iso8601(3)"
 	}
 }
 				

--- a/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
+++ b/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
@@ -14,13 +14,17 @@ filter {
 		add_field => [ "@source.offset", "%{offset}" ]
 		remove_field => [ "host", "file", "offset" ]
 
-		add_field => [ "@ingestor[service]", "lumberjack" ]
-		add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
+	    <% if 'DEBUG' == p('logstash.metadata_level') %>
+			add_field => [ "@ingestor[service]", "lumberjack" ]
+			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
+		<% end %>
 	}
 
-	ruby {
-		code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
-	}
+    <% if 'DEBUG' == p('logstash.metadata_level') %>
+		ruby {
+			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
+		}
+	<% end %>
 }
 				
 output {

--- a/jobs/ingestor_relp/spec
+++ b/jobs/ingestor_relp/spec
@@ -11,6 +11,10 @@ templates:
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   config/relp_to_redis.conf.erb: config/relp_to_redis.conf
 properties:
+  logstash.metadata_level:
+    description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
+    default: "NONE"
+
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
+++ b/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
@@ -5,6 +5,17 @@ input {
 		port => "<%= p("logstash_ingestor.relp.port") %>"
 	}
 }
+
+filter {
+	mutate {
+		add_field => [ "@ingestor.service", "relp" ]
+		add_field => [ "@ingestor.job", "<%= name %>/<%= index %>" ]
+	}
+
+	ruby {
+		code => "event['@ingestor.timestamp'] = Time.now.iso8601(3)"
+	}
+}
 			
 output {
 	<% if p("logstash_ingestor.debug") %>

--- a/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
+++ b/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
@@ -8,12 +8,12 @@ input {
 
 filter {
 	mutate {
-		add_field => [ "@ingestor.service", "relp" ]
-		add_field => [ "@ingestor.job", "<%= name %>/<%= index %>" ]
+		add_field => [ "@ingestor[service]", "relp" ]
+		add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
 	}
 
 	ruby {
-		code => "event['@ingestor.timestamp'] = Time.now.iso8601(3)"
+		code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
 	}
 }
 			

--- a/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
+++ b/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
@@ -6,16 +6,18 @@ input {
 	}
 }
 
-filter {
-	mutate {
-		add_field => [ "@ingestor[service]", "relp" ]
-		add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
-	}
+<% if 'DEBUG' == p('logstash.metadata_level') %>
+	filter {
+		mutate {
+			add_field => [ "@ingestor[service]", "relp" ]
+			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
+		}
 
-	ruby {
-		code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
+		ruby {
+			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
+		}
 	}
-}
+<% end %>
 			
 output {
 	<% if p("logstash_ingestor.debug") %>

--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -13,6 +13,10 @@ templates:
   config/syslog_tls.key.erb: config/syslog_tls.key
   config/syslog_to_redis.conf.erb: config/syslog_to_redis.conf
 properties:
+  logstash.metadata_level:
+    description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
+    default: "NONE"
+
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -24,19 +24,21 @@ input {
 	<% end %>
 }
 
-filter {
-    mutate {
-        rename => [ "host", "@ingestor.remote_host" ]
-        rename => [ "sslsubject", "@ingestor.sslsubject" ]
+<% if 'DEBUG' == p('logstash.metadata_level') %>
+	filter {
+	    mutate {
+	        rename => [ "host", "@ingestor.remote_host" ]
+	        rename => [ "sslsubject", "@ingestor.sslsubject" ]
 
-		add_field => [ "@ingestor[service]", "syslog" ]
-		add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
-    }
+			add_field => [ "@ingestor[service]", "syslog" ]
+			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
+	    }
 
-	ruby {
-		code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
+		ruby {
+			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
+		}
 	}
-}
+<% end %>
 
 output {
 	<% if p("logstash_ingestor.debug") %>

--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -29,12 +29,12 @@ filter {
         rename => [ "host", "@ingestor.remote_host" ]
         rename => [ "sslsubject", "@ingestor.sslsubject" ]
 
-		add_field => [ "@ingestor.service", "syslog" ]
-		add_field => [ "@ingestor.job", "<%= name %>/<%= index %>" ]
+		add_field => [ "@ingestor[service]", "syslog" ]
+		add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
     }
 
 	ruby {
-		code => "event['@ingestor.timestamp'] = Time.now.iso8601(3)"
+		code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
 	}
 }
 

--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -28,7 +28,14 @@ filter {
     mutate {
         rename => [ "host", "@ingestor.remote_host" ]
         rename => [ "sslsubject", "@ingestor.sslsubject" ]
+
+		add_field => [ "@ingestor.service", "syslog" ]
+		add_field => [ "@ingestor.job", "<%= name %>/<%= index %>" ]
     }
+
+	ruby {
+		code => "event['@ingestor.timestamp'] = Time.now.iso8601(3)"
+	}
 }
 
 output {

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -15,6 +15,10 @@ templates:
   config/filters_default.conf: config/filters_default.conf
   config/filters_override.conf.erb: config/filters_override.conf
 properties:
+  logstash.metadata_level:
+    description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
+    default: "NONE"
+
   logstash_parser.debug:
     description: Debug level logging
     default: false

--- a/jobs/log_parser/templates/config/filters_post.conf.erb
+++ b/jobs/log_parser/templates/config/filters_post.conf.erb
@@ -1,6 +1,8 @@
 
-    ruby {
-        code => "n = Time.now ; event['@parser[duration]'] = (1000 * (n - Time.parse(event['@parser[timestamp]']))).to_i ; event['@timer[ingested_to_parsed]'] = (1000 * (n - Time.parse(event['@ingestor[timestamp]']))).to_i ; if event['@timestamp'].instance_of? Time ; event['@timer[emit_to_ingested]'] = (1000 * (Time.parse(event['@ingestor[timestamp]']) - event['@timestamp'])).to_i ; event['@timer[emit_to_parsed]'] = (1000 * (n - event['@timestamp'])).to_i ; end"
-    }
+    <% if 'DEBUG' == p('logstash.metadata_level') %>
+        ruby {
+            code => "n = Time.now ; event['@parser[duration]'] = (1000 * (n - Time.parse(event['@parser[timestamp]']))).to_i ; event['@timer[ingested_to_parsed]'] = (1000 * (n - Time.parse(event['@ingestor[timestamp]']))).to_i ; if event['@timestamp'].instance_of? Time ; event['@timer[emit_to_ingested]'] = (1000 * (Time.parse(event['@ingestor[timestamp]']) - event['@timestamp'])).to_i ; event['@timer[emit_to_parsed]'] = (1000 * (n - event['@timestamp'])).to_i ; end"
+        }
+    <% end %>
 
 }

--- a/jobs/log_parser/templates/config/filters_post.conf.erb
+++ b/jobs/log_parser/templates/config/filters_post.conf.erb
@@ -1,7 +1,15 @@
 
     <% if 'DEBUG' == p('logstash.metadata_level') %>
         ruby {
-            code => "n = Time.now ; event['@parser[duration]'] = (1000 * (n - Time.parse(event['@parser[timestamp]']))).to_i ; event['@timer[ingested_to_parsed]'] = (1000 * (n - Time.parse(event['@ingestor[timestamp]']))).to_i ; if event['@timestamp'].instance_of? Time ; event['@timer[emit_to_ingested]'] = (1000 * (Time.parse(event['@ingestor[timestamp]']) - event['@timestamp'])).to_i ; event['@timer[emit_to_parsed]'] = (1000 * (n - event['@timestamp'])).to_i ; end"
+            code => "
+                n = Time.now
+                event['@parser[duration]'] = (1000 * (n - Time.parse(event['@parser[timestamp]']))).to_i
+                event['@timer[ingested_to_parsed]'] = (1000 * (n - Time.parse(event['@ingestor[timestamp]']))).to_i if event['@ingestor[timestamp]']
+                if event['@timestamp'].instance_of? Time
+                    event['@timer[emit_to_ingested]'] = (1000 * (Time.parse(event['@ingestor[timestamp]']) - event['@timestamp'])).to_i if event['@ingestor[timestamp]']
+                    event['@timer[emit_to_parsed]'] = (1000 * (n - event['@timestamp'])).to_i
+                end
+            "
         }
     <% end %>
 

--- a/jobs/log_parser/templates/config/filters_post.conf.erb
+++ b/jobs/log_parser/templates/config/filters_post.conf.erb
@@ -1,2 +1,6 @@
 
+    ruby {
+        code => "n = Time.now ; event['@timer.parser'] = (1000 * (n - Time.parse(event['@parser.timestamp']))).to_i ; if event['@timestamp'].instance_of? Time ; event['@timer.event_lag'] = (1000 * (n - event['@timestamp'])).to_i ; event['@timer.ingestion_lag'] = (1000 * (n - Time.parse(event['@ingestor.timestamp']))).to_i ; end"
+    }
+
 }

--- a/jobs/log_parser/templates/config/filters_post.conf.erb
+++ b/jobs/log_parser/templates/config/filters_post.conf.erb
@@ -1,6 +1,6 @@
 
     ruby {
-        code => "n = Time.now ; event['@timer.parser'] = (1000 * (n - Time.parse(event['@parser.timestamp']))).to_i ; if event['@timestamp'].instance_of? Time ; event['@timer.event_lag'] = (1000 * (n - event['@timestamp'])).to_i ; event['@timer.ingestion_lag'] = (1000 * (n - Time.parse(event['@ingestor.timestamp']))).to_i ; end"
+        code => "n = Time.now ; event['@parser[duration]'] = (1000 * (n - Time.parse(event['@parser[timestamp]']))).to_i ; event['@timer[ingested_to_parsed]'] = (1000 * (n - Time.parse(event['@ingestor[timestamp]']))).to_i ; if event['@timestamp'].instance_of? Time ; event['@timer[emit_to_ingested]'] = (1000 * (Time.parse(event['@ingestor[timestamp]']) - event['@timestamp'])).to_i ; event['@timer[emit_to_parsed]'] = (1000 * (n - event['@timestamp'])).to_i ; end"
     }
 
 }

--- a/jobs/log_parser/templates/config/filters_pre.conf.erb
+++ b/jobs/log_parser/templates/config/filters_pre.conf.erb
@@ -1,12 +1,14 @@
 filter {
 
-    mutate {
-        add_field => [ "@parser[job]", "<%= name %>/<%= index %>" ]
-    }
+    <% if 'DEBUG' == p('logstash.metadata_level') %>
+        mutate {
+            add_field => [ "@parser[job]", "<%= name %>/<%= index %>" ]
+        }
 
-    ruby {
-        code => "event['@parser[timestamp]'] = Time.now.iso8601(3)"
-    }
+        ruby {
+            code => "event['@parser[timestamp]'] = Time.now.iso8601(3)"
+        }
+    <% end %>
 
     #
     # Default type to _logstash_input 

--- a/jobs/log_parser/templates/config/filters_pre.conf.erb
+++ b/jobs/log_parser/templates/config/filters_pre.conf.erb
@@ -1,5 +1,13 @@
 filter {
 
+    mutate {
+        add_field => [ "@parser.job", "<%= name %>/<%= index %>" ]
+    }
+
+    ruby {
+        code => "event['@parser.timestamp'] = Time.now.iso8601(3)"
+    }
+
     #
     # Default type to _logstash_input 
     #

--- a/jobs/log_parser/templates/config/filters_pre.conf.erb
+++ b/jobs/log_parser/templates/config/filters_pre.conf.erb
@@ -1,11 +1,11 @@
 filter {
 
     mutate {
-        add_field => [ "@parser.job", "<%= name %>/<%= index %>" ]
+        add_field => [ "@parser[job]", "<%= name %>/<%= index %>" ]
     }
 
     ruby {
-        code => "event['@parser.timestamp'] = Time.now.iso8601(3)"
+        code => "event['@parser[timestamp]'] = Time.now.iso8601(3)"
     }
 
     #

--- a/share/kibana-dashboards/event-pipeline-metrics.json
+++ b/share/kibana-dashboards/event-pipeline-metrics.json
@@ -1,0 +1,790 @@
+{
+  "title": "Event Pipeline Metrics",
+  "services": {
+    "query": {
+      "list": {
+        "0": {
+          "id": 0,
+          "type": "topN",
+          "query": "*",
+          "alias": "@type",
+          "color": "#7EB26D",
+          "pin": false,
+          "enable": true,
+          "field": "@type",
+          "size": 20,
+          "union": "AND"
+        }
+      },
+      "ids": [
+        0
+      ]
+    },
+    "filter": {
+      "list": {
+        "0": {
+          "type": "time",
+          "field": "@timestamp",
+          "from": "now-6h",
+          "to": "now",
+          "mandate": "must",
+          "active": true,
+          "alias": "",
+          "id": 0
+        }
+      },
+      "ids": [
+        0
+      ]
+    }
+  },
+  "rows": [
+    {
+      "title": "Max",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 3,
+          "editable": true,
+          "group": [
+            "default"
+          ],
+          "type": "histogram",
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "@timer.emit_to_ingested",
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "fill": 0,
+          "linewidth": 1,
+          "timezone": "browser",
+          "spyable": true,
+          "zoomlinks": true,
+          "bars": false,
+          "stack": false,
+          "points": false,
+          "lines": true,
+          "legend": false,
+          "x-axis": true,
+          "y-axis": true,
+          "percentage": false,
+          "interactive": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "title": "emit_to_ingested (max)",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1M",
+            "1y"
+          ],
+          "options": true,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "pointradius": 5,
+          "show_query": true,
+          "legend_counts": true,
+          "zerofill": true,
+          "derivative": false
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "@timer.ingested_to_parsed",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "ingested_to_parsed (max)"
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "@parser.duration",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Parsing duration (max)"
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "@timer.emit_to_parsed",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "emit_to_parsed (max)"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Mean",
+      "height": "150px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "@timer.emit_to_ingested",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "emit_to_ingested (mean)"
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "@timer.ingested_to_parsed",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "ingested_to_parsed (mean)"
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "@parser.duration",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": false,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Parsing duration (mean)"
+        },
+        {
+          "span": 3,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "@timer.emit_to_parsed",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "emit_to_parsed (mean)"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Raw Data",
+      "height": "350px",
+      "editable": true,
+      "collapse": true,
+      "collapsable": true,
+      "panels": [
+        {
+          "title": "All events",
+          "error": false,
+          "span": 12,
+          "editable": true,
+          "group": [
+            "default"
+          ],
+          "type": "table",
+          "size": 100,
+          "pages": 5,
+          "offset": 0,
+          "sort": [
+            "@timestamp",
+            "desc"
+          ],
+          "style": {
+            "font-size": "9pt"
+          },
+          "overflow": "min-height",
+          "fields": [
+            "@timestamp",
+            "@type",
+            "@ingestor.job",
+            "@ingestor.timestamp",
+            "@parser.timestamp",
+            "@parser.job",
+            "@timer.emit_to_ingested",
+            "@timer.ingested_to_parsed",
+            "@timer.emit_to_parsed"
+          ],
+          "localTime": true,
+          "timeField": "@timestamp",
+          "highlight": [],
+          "sortable": true,
+          "header": true,
+          "paging": true,
+          "spyable": true,
+          "queries": {
+            "mode": "all",
+            "ids": [
+              0
+            ]
+          },
+          "field_list": false,
+          "status": "Stable",
+          "trimFactor": 300,
+          "normTimes": true,
+          "all_fields": false
+        }
+      ],
+      "notice": false
+    }
+  ],
+  "editable": true,
+  "failover": false,
+  "index": {
+    "interval": "day",
+    "pattern": "[logstash-]YYYY.MM.DD",
+    "default": "NO_TIME_FILTER_OR_INDEX_PATTERN_NOT_MATCHED",
+    "warm_fields": true
+  },
+  "style": "dark",
+  "panel_hints": true,
+  "pulldowns": [
+    {
+      "type": "query",
+      "collapse": true,
+      "notice": false,
+      "query": "*",
+      "pinned": true,
+      "history": [
+        "*"
+      ],
+      "remember": 10,
+      "enable": true
+    },
+    {
+      "type": "filtering",
+      "collapse": true,
+      "notice": false,
+      "enable": true
+    }
+  ],
+  "nav": [
+    {
+      "type": "timepicker",
+      "collapse": false,
+      "notice": false,
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "timefield": "@timestamp",
+      "now": true,
+      "filter_id": 0,
+      "enable": true
+    }
+  ],
+  "loader": {
+    "save_gist": false,
+    "save_elasticsearch": true,
+    "save_local": true,
+    "save_default": true,
+    "save_temp": true,
+    "save_temp_ttl_enable": true,
+    "save_temp_ttl": "30d",
+    "load_gist": true,
+    "load_elasticsearch": true,
+    "load_elasticsearch_size": 20,
+    "load_local": true,
+    "hide": false
+  },
+  "refresh": false
+}

--- a/share/kibana-dashboards/event-pipeline-metrics.json
+++ b/share/kibana-dashboards/event-pipeline-metrics.json
@@ -14,10 +14,49 @@
           "field": "@type",
           "size": 20,
           "union": "AND"
+        },
+        "1": {
+          "id": 1,
+          "type": "topN",
+          "query": "*",
+          "alias": "by Ingestor",
+          "color": "#6ED0E0",
+          "pin": true,
+          "enable": true,
+          "field": "@ingestor.job",
+          "size": 16,
+          "union": "AND"
+        },
+        "2": {
+          "id": 2,
+          "type": "topN",
+          "query": "*",
+          "alias": "by Parser",
+          "color": "#EF843C",
+          "pin": true,
+          "enable": true,
+          "field": "@parser.job",
+          "size": 16,
+          "union": "AND"
+        },
+        "3": {
+          "id": 3,
+          "type": "topN",
+          "query": "*",
+          "alias": "by Type",
+          "color": "#EAB839",
+          "pin": true,
+          "enable": true,
+          "field": "@type",
+          "size": 16,
+          "union": "AND"
         }
       },
       "ids": [
-        0
+        0,
+        1,
+        2,
+        3
       ]
     },
     "filter": {
@@ -40,10 +79,322 @@
   },
   "rows": [
     {
-      "title": "Max",
+      "title": "Throughput",
+      "height": "180px",
+      "editable": true,
+      "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 6,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "count",
+          "time_field": "@ingestor.timestamp",
+          "value_field": null,
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              1
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 2,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": true,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": false,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "Ingested Messages"
+        },
+        {
+          "span": 6,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "count",
+          "time_field": "@parser.timestamp",
+          "value_field": null,
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              2
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 1,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": true,
+          "spyable": true,
+          "zoomlinks": false,
+          "options": false,
+          "legend": false,
+          "show_query": false,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "individual",
+            "query_as_alias": true
+          },
+          "title": "Parsed Messages"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Duration",
       "height": "150px",
       "editable": true,
       "collapse": false,
+      "collapsable": true,
+      "panels": [
+        {
+          "span": 6,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "max",
+          "time_field": "@timestamp",
+          "value_field": "@parser.duration",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              3
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": true,
+          "interactive": true,
+          "legend_counts": true,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Parsing duration (max)"
+        },
+        {
+          "span": 6,
+          "editable": true,
+          "type": "histogram",
+          "loadingEditor": false,
+          "mode": "mean",
+          "time_field": "@timestamp",
+          "value_field": "@parser.duration",
+          "x-axis": true,
+          "y-axis": true,
+          "scale": 1,
+          "y_format": "short",
+          "grid": {
+            "max": null,
+            "min": 0
+          },
+          "queries": {
+            "mode": "selected",
+            "ids": [
+              3
+            ]
+          },
+          "annotate": {
+            "enable": false,
+            "query": "*",
+            "size": 20,
+            "field": "_type",
+            "sort": [
+              "_score",
+              "desc"
+            ]
+          },
+          "auto_int": false,
+          "resolution": 100,
+          "interval": "1m",
+          "intervals": [
+            "auto",
+            "1s",
+            "1m",
+            "5m",
+            "10m",
+            "30m",
+            "1h",
+            "3h",
+            "12h",
+            "1d",
+            "1w",
+            "1y"
+          ],
+          "lines": true,
+          "fill": 0,
+          "linewidth": 1,
+          "points": false,
+          "pointradius": 5,
+          "bars": false,
+          "stack": false,
+          "spyable": true,
+          "zoomlinks": true,
+          "options": true,
+          "legend": false,
+          "show_query": false,
+          "interactive": true,
+          "legend_counts": false,
+          "timezone": "browser",
+          "percentage": false,
+          "zerofill": true,
+          "derivative": false,
+          "tooltip": {
+            "value_type": "cumulative",
+            "query_as_alias": true
+          },
+          "title": "Parsing duration (mean)"
+        }
+      ],
+      "notice": false
+    },
+    {
+      "title": "Max",
+      "height": "150px",
+      "editable": true,
+      "collapse": true,
       "collapsable": true,
       "panels": [
         {
@@ -74,9 +425,9 @@
           "percentage": false,
           "interactive": true,
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              3
             ]
           },
           "title": "emit_to_ingested (max)",
@@ -139,9 +490,9 @@
             "min": 0
           },
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              3
             ]
           },
           "annotate": {
@@ -202,79 +553,6 @@
           "loadingEditor": false,
           "mode": "max",
           "time_field": "@timestamp",
-          "value_field": "@parser.duration",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_format": "short",
-          "grid": {
-            "max": null,
-            "min": 0
-          },
-          "queries": {
-            "mode": "all",
-            "ids": [
-              0
-            ]
-          },
-          "annotate": {
-            "enable": false,
-            "query": "*",
-            "size": 20,
-            "field": "_type",
-            "sort": [
-              "_score",
-              "desc"
-            ]
-          },
-          "auto_int": false,
-          "resolution": 100,
-          "interval": "1m",
-          "intervals": [
-            "auto",
-            "1s",
-            "1m",
-            "5m",
-            "10m",
-            "30m",
-            "1h",
-            "3h",
-            "12h",
-            "1d",
-            "1w",
-            "1y"
-          ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": true,
-          "options": true,
-          "legend": false,
-          "show_query": true,
-          "interactive": true,
-          "legend_counts": true,
-          "timezone": "browser",
-          "percentage": false,
-          "zerofill": true,
-          "derivative": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "title": "Parsing duration (max)"
-        },
-        {
-          "span": 3,
-          "editable": true,
-          "type": "histogram",
-          "loadingEditor": false,
-          "mode": "max",
-          "time_field": "@timestamp",
           "value_field": "@timer.emit_to_parsed",
           "x-axis": true,
           "y-axis": true,
@@ -285,9 +563,9 @@
             "min": 0
           },
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              3
             ]
           },
           "annotate": {
@@ -348,7 +626,7 @@
       "title": "Mean",
       "height": "150px",
       "editable": true,
-      "collapse": false,
+      "collapse": true,
       "collapsable": true,
       "panels": [
         {
@@ -368,9 +646,9 @@
             "min": 0
           },
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              3
             ]
           },
           "annotate": {
@@ -441,9 +719,9 @@
             "min": 0
           },
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              3
             ]
           },
           "annotate": {
@@ -504,79 +782,6 @@
           "loadingEditor": false,
           "mode": "mean",
           "time_field": "@timestamp",
-          "value_field": "@parser.duration",
-          "x-axis": true,
-          "y-axis": true,
-          "scale": 1,
-          "y_format": "short",
-          "grid": {
-            "max": null,
-            "min": 0
-          },
-          "queries": {
-            "mode": "all",
-            "ids": [
-              0
-            ]
-          },
-          "annotate": {
-            "enable": false,
-            "query": "*",
-            "size": 20,
-            "field": "_type",
-            "sort": [
-              "_score",
-              "desc"
-            ]
-          },
-          "auto_int": false,
-          "resolution": 100,
-          "interval": "1m",
-          "intervals": [
-            "auto",
-            "1s",
-            "1m",
-            "5m",
-            "10m",
-            "30m",
-            "1h",
-            "3h",
-            "12h",
-            "1d",
-            "1w",
-            "1y"
-          ],
-          "lines": true,
-          "fill": 0,
-          "linewidth": 1,
-          "points": false,
-          "pointradius": 5,
-          "bars": false,
-          "stack": false,
-          "spyable": true,
-          "zoomlinks": true,
-          "options": true,
-          "legend": false,
-          "show_query": false,
-          "interactive": true,
-          "legend_counts": false,
-          "timezone": "browser",
-          "percentage": false,
-          "zerofill": true,
-          "derivative": false,
-          "tooltip": {
-            "value_type": "cumulative",
-            "query_as_alias": true
-          },
-          "title": "Parsing duration (mean)"
-        },
-        {
-          "span": 3,
-          "editable": true,
-          "type": "histogram",
-          "loadingEditor": false,
-          "mode": "mean",
-          "time_field": "@timestamp",
           "value_field": "@timer.emit_to_parsed",
           "x-axis": true,
           "y-axis": true,
@@ -587,9 +792,9 @@
             "min": 0
           },
           "queries": {
-            "mode": "all",
+            "mode": "selected",
             "ids": [
-              0
+              3
             ]
           },
           "annotate": {
@@ -666,7 +871,7 @@
           "pages": 5,
           "offset": 0,
           "sort": [
-            "@timestamp",
+            "@ingestor.timestamp",
             "desc"
           ],
           "style": {
@@ -674,15 +879,13 @@
           },
           "overflow": "min-height",
           "fields": [
-            "@timestamp",
-            "@type",
-            "@ingestor.job",
             "@ingestor.timestamp",
-            "@parser.timestamp",
+            "@ingestor.job",
             "@parser.job",
-            "@timer.emit_to_ingested",
+            "@parser.duration",
             "@timer.ingested_to_parsed",
-            "@timer.emit_to_parsed"
+            "@type",
+            "@timestamp"
           ],
           "localTime": true,
           "timeField": "@timestamp",
@@ -694,7 +897,10 @@
           "queries": {
             "mode": "all",
             "ids": [
-              0
+              0,
+              1,
+              2,
+              3
             ]
           },
           "field_list": false,
@@ -733,7 +939,7 @@
     {
       "type": "filtering",
       "collapse": true,
-      "notice": false,
+      "notice": true,
       "enable": true
     }
   ],


### PR DESCRIPTION
Add additional metadata fields...
- `@ingestor.service` - arbitrary input method (e.g. `lumberjack`, `syslog`)
- `@ingestor.job` - the job name and index from whichever ingestor received the event (e.g. `ingestor/0`)
- `@ingestor.timestamp` - timestamp the ingestor received the event
- `@parser.job` - the job name and index from whichever parser processed the event
- `@parser.timestamp` - timestamp the parser received the event
- `@parser.duration` - time (ms) the parser spent parsing the message
- `@timer.emit_to_ingested` - time delta (ms) between when the event was emitted and received by the ingestor
- `@timer.emit_to_parsed` - time delta (ms) between when the event was emitted and fully parsed
- `@timer.ingested_to_parsed` - time delta (ms) between when the event was ingested and fully parsed (essentially the total time logsearch was involved)

The `@timer.emit_` values make several assumptions - namely that the log emitter has an accurate time. Additionally, logs that don't provide millisecond times will generally hover ~500 ms due to `ms - s` deltas.
