### PR TITLE
Switch parsers to using a local elasticsearch client node

### DIFF
--- a/jobs/log_parser/monit
+++ b/jobs/log_parser/monit
@@ -3,3 +3,11 @@ check process log_parser
   start program "/var/vcap/jobs/log_parser/bin/monit_debugger log_parser_ctl '/var/vcap/jobs/log_parser/bin/log_parser_ctl start'"
   stop program "/var/vcap/jobs/log_parser/bin/monit_debugger log_parser_ctl '/var/vcap/jobs/log_parser/bin/log_parser_ctl stop'"
   group vcap
+
+<% if p('logstash_parser.use_local_elasticsearch') %>
+  check process log_parser-elasticsearch
+    with pidfile /var/vcap/sys/run/log_parser/elasticsearch.pid
+    start program "/var/vcap/jobs/log_parser/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/log_parser/bin/elasticsearch_ctl start'"
+    stop program "/var/vcap/jobs/log_parser/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/log_parser/bin/elasticsearch_ctl stop'"
+    group vcap
+<% end %>

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -2,18 +2,23 @@
 name: log_parser
 packages: 
 - logstash
+- elasticsearch
 - java7
 templates:
   bin/log_parser_ctl: bin/log_parser_ctl
+  bin/elasticsearch_ctl: bin/elasticsearch_ctl
   bin/monit_debugger: bin/monit_debugger
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
+  config/elasticsearch/default.json.erb: config/elasticsearch/default.json
+  config/elasticsearch/logging.yml.erb: config/elasticsearch/logging.yml
   config/input_redis_and_output_elasticsearch.conf.erb: config/input_redis_and_output_elasticsearch.conf
   config/filters_pre.conf.erb: config/filters_pre.conf
   config/filters_post.conf.erb: config/filters_post.conf
   config/filters_default.conf: config/filters_default.conf
   config/filters_override.conf.erb: config/filters_override.conf
+  logsearch/logs.yml: logsearch/logs.yml
 properties:
   logstash.metadata_level:
     description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
@@ -33,6 +38,9 @@ properties:
     default: auto
   logstash_parser.idle_flush_time:
     description: "How frequently to flush events if the output queue is not full."
+  logstash_parser.use_local_elasticsearch:
+    description: "Run a local elasticsearch client node"
+    default: true
 
   elasticsearch.host:
     description: IP / DNS of elasticsearch http endpoint
@@ -42,6 +50,16 @@ properties:
   elasticsearch.flush_size:
     description: Redis queue flush size
     default: 100
+  elasticsearch.cluster_name:
+    description: The name of the elastic search cluster
+  elasticsearch.log_level:
+    description: The default logging level (e.g. WARN, DEBUG, INFO)
+    default: INFO
+  elasticsearch.marvel.agent.enabled:
+    description: Whether to enable the marvel agent
+    default: false
+  elasticsearch.node.tags:
+    description: A hash of additional tags for the node
 
   redis.host: 
     description: Redis host of queue

--- a/jobs/log_parser/templates/bin/elasticsearch_ctl
+++ b/jobs/log_parser/templates/bin/elasticsearch_ctl
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/log_parser/helpers/ctl_setup.sh 'log_parser' 'elasticsearch'
+
+export PIDFILE=$RUN_DIR/elasticsearch.pid
+export PORT=${PORT:-5000}
+export LANG=en_US.UTF-8
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME/elasticsearch
+
+    /var/vcap/jobs/elasticsearch/bin/undrain 2>&1 >> $LOG_DIR/undrain.log &
+
+    exec /var/vcap/packages/elasticsearch/bin/elasticsearch \
+         -Des.config=${JOB_DIR}/config/elasticsearch/default.json \
+         -XX:HeapDumpPath=${TMPDIR}/heap-dump/ \
+         -Des.pidfile=${PIDFILE} \
+         >>$LOG_DIR/elasticsearch.stdout.log \
+         2>>$LOG_DIR/elasticsearch.stderr.log
+
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: elasticsearch_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/log_parser/templates/config/elasticsearch/default.json.erb
+++ b/jobs/log_parser/templates/config/elasticsearch/default.json.erb
@@ -1,0 +1,84 @@
+{
+  "cluster.name" : "<%= p("elasticsearch.cluster_name") %>",
+  "node" : {
+    "name" : "<%= name %>/<%= index %>",
+    "master" : false,
+    "data" : false,
+    "job_name" : "<%= name %>",
+    "job_index" : "<%= index %>"
+    <% p("elasticsearch.node.tags", {}).each do | k, v | %>,
+      "<%= k %>" : "<%= v %>"
+    <% end %>
+  },
+  "discovery.zen.ping.multicast.enabled": false,
+<% if_p("elasticsearch.host") do %>
+  "discovery.zen.ping.unicast.hosts" : "<%= p("elasticsearch.host") %>",
+<% end %>
+  "path.conf" : "/var/vcap/jobs/log_parser/config/elasticsearch",
+  "path.logs" : "/var/vcap/sys/log/log_parser",
+  "network.host" : "0.0.0.0",
+  "http.type" : "com.sonian.elasticsearch.http.filter.FilterHttpServerTransportModule",
+  "marvel.agent.enabled" : <%= p('elasticsearch.marvel.agent.enabled') %>,
+
+  "sonian" : {
+    "elasticsearch" : {
+      "http" : {
+        "filter" : {
+          "http_filter_chain" : [
+            "logging"
+          ],
+          "http_filter" : {
+            "logging" : {
+              "type" : "com.sonian.elasticsearch.http.filter.logging.LoggingFilterHttpServerAdapter",
+              "logger" : "request",
+              "format" : "json",
+              "level" : "INFO",
+              "log_body" : false,
+              "loggers" : {
+                "stats" : {
+                  "path" : [
+                    "/_cluster/health",
+                    "/_cluster/nodes",
+                    "/_cluster/state",
+                    "/_cluster/nodes/{node}/stats"
+                  ],
+                  "method" : [
+                    "GET"
+                  ],
+                  "level" : "TRACE"
+                },
+                "searches" : {
+                  "path" : [
+                    "/_search",
+                    "/_search/scroll",
+                    "/_search/scroll/{scroll_id}",
+                    "/{index}/_search",
+                    "/{index}/{type}/_search",
+                    "/{index}/{type}/{id}/_mlt"
+                  ],
+                  "method" : [
+                    "GET",
+                    "POST"
+                  ],
+                  "log_body": true
+                },
+                "count" : {
+                  path: [
+                    "/_count",
+                    "/{index}/_count",
+                    "/{index}/{type}/_count"
+                  ],
+                  "method" : [
+                    "GET",
+                    "POST"
+                  ],
+                  "log_body" : true
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/jobs/log_parser/templates/config/elasticsearch/logging.yml.erb
+++ b/jobs/log_parser/templates/config/elasticsearch/logging.yml.erb
@@ -1,0 +1,20 @@
+rootLogger: <%= p("elasticsearch.log_level") %>, console
+logger:
+  request: INFO, request_log_file
+
+additivity:
+  request: false
+
+appender:
+  console:
+    type: console
+    layout:
+      type: consolePattern
+      conversionPattern: "[%d{ISO8601}][%-5p][%-25c] %m%n"
+
+  request_log_file:
+    type: file
+    file: ${path.logs}/elasticsearch.requests.log
+    layout:
+      type: pattern
+      conversionPattern: "%m%n"

--- a/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
@@ -18,7 +18,7 @@ output {
     <% end %>
 
     elasticsearch_http {
-        host => "<%= p("elasticsearch.host") %>:<%= p("elasticsearch.port") %>"
+        host => "<%= p('logstash_parser.use_local_elasticsearch') ? '127.0.0.1' : p("elasticsearch.host") %>:<%= p("elasticsearch.port") %>"
         flush_size => <%= p("elasticsearch.flush_size") %>
         <% if p('logstash_parser.idle_flush_time', nil) %>
             idle_flush_time => <%= p('logstash_parser.idle_flush_time') %>

--- a/jobs/log_parser/templates/logsearch/logs.yml
+++ b/jobs/log_parser/templates/logsearch/logs.yml
@@ -1,0 +1,4 @@
+files:
+  "log_parser/elasticsearch.requests.log":
+    fields:
+      type: "elasticsearch_request"


### PR DESCRIPTION
The logstash parsers currently have a single point of failure because they can only talk to one elasticsearch host at a time. The alternatives are to switch to logstash's embedded elasticsearch client or to run your own in order to utilize elasticsearch's built-in cluster discovery capabilities.

Here I've opted to using our own packaged version rather than the (generally outdated) embedded version logstash has because it allows us to run the same elasticsearch version throughout the cluster and avoid the occasional bugs in running differing versions. This also lets us continue to use the sonian plugin to log the bulk indexing requests logstash makes and graph those times. Since parsers should be very ephemeral, elasticsearch is configured as a client node and will not become master nor will it store any data.

I've included a boolean property `logstash_parser.use_local_elasticsearch` which allows disabling the functionality (in the case of co-locating everything on micro installs).
