### PR TITLE
Allow additional outputs

### DIFF
--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -33,6 +33,8 @@ properties:
   logstash_parser.filters:
     description: "The configuration to embed into the logstash filters section"
     default: ''
+  logstash_parser.outputs:
+    description: "The configuration to embed into the logstash outputs section"
   logstash_parser.workers:
     description: "The number of worker threads that logstash should use (default: auto = one per CPU)"
     default: auto

--- a/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
@@ -26,4 +26,6 @@ output {
         index_type => "%{@type}"
         manage_template => false
     }
+
+    <%= p('logstash_parser.outputs', '')  %>
 }


### PR DESCRIPTION
This PR adds support for additional outputs to be specified via the deployment manifest.
Our current use case for this is wanting to ship logs parsed logs to our central log storage solution for long term storage. But have recent logs available in elasticsearch.
