### PR TITLE
Allow customizing document id, index, and index type

### DIFF
--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -40,6 +40,15 @@ properties:
     default: auto
   logstash_parser.idle_flush_time:
     description: "How frequently to flush events if the output queue is not full."
+  logstash_parser.elasticsearch_document_id:
+    description: "Use a specific, dynamic ID rather than an auto-generated identifier."
+    default: ~
+  logstash_parser.elasticsearch_index:
+    description: "The specific, dynamic index name to write events to."
+    default: "logstash-%{+YYYY.MM.dd}"
+  logstash_parser.elasticsearch_index_type:
+    description: "The specific, dynamic index type name to write events to."
+    default: "%{@type}"
   logstash_parser.use_local_elasticsearch:
     description: "Run a local elasticsearch client node"
     default: true

--- a/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
@@ -23,7 +23,11 @@ output {
         <% if p('logstash_parser.idle_flush_time', nil) %>
             idle_flush_time => <%= p('logstash_parser.idle_flush_time') %>
         <% end %>
-        index_type => "%{@type}"
+        <% if p('logstash_parser.elasticsearch_document_id', nil) %>
+            document_id => "<%= p('logstash_parser.elasticsearch_document_id') %>"
+        <% end %>
+        index => "<%= p('logstash_parser.elasticsearch_index') %>"
+        index_type => "<%= p('logstash_parser.elasticsearch_index_type') %>"
         manage_template => false
     }
 


### PR DESCRIPTION
This allows users to customize the `document_id`, `index`, and `index_type` options of the `elasticsearch_http` output used by the log parsers. The `index` and `index_type` are the main ones I'm interested in (to support weekly indices and multi-field type names). I went ahead and included `document_id` since `l4aws` was overwriting it and it kind of correlates with index/type name settings, but I don't really have a specific need for it at the moment.

The three new properties are all defaulted to what the existing values have been.

Partially in reference to issue #68.
