### PR TITLE
Adding skip option

### DIFF
--- a/share/util/elasticsearch-rolling-restart
+++ b/share/util/elasticsearch-rolling-restart
@@ -29,6 +29,13 @@ for NODEREF in $( curl -s "${CLUSTER}/_cat/nodes?h=host,node.role,master,name" |
   NODE=$( echo "${NODEREF}" | awk -F '|' '{ print $1 }' )
   NODE_NAME=$( echo "${NODEREF}" | awk -F '|' '{ print $2 }' )
 
+  /bin/echo "To skip node ${NODE_NAME}, enter 's' -- any other key will shut it down for maintenance"
+  read SKIP
+  if [ ${SKIP} = "s" ]
+  then
+    continue
+  fi
+
   decho "> restarting ${NODE_NAME}"
 
 

--- a/share/util/elasticsearch-rolling-restart
+++ b/share/util/elasticsearch-rolling-restart
@@ -3,13 +3,19 @@
 #
 # perform a rolling restart of all data/master nodes in a stable cluster
 #
-# args: [elasticsearch-host:port]
+# args: [elasticsearch-host:port] -i|--interactive
 #
 
 set -e
 set -u
 
 CLUSTER="${1:-localhost:9200}"
+INTERACTIVE="${2:-false}"
+
+if [[ ${2} == "-i" ]] || [[ ${2} == "--interactive" ]]
+then
+  INTERACTIVE=true
+fi
 
 function decho {
   /bin/echo $( date -u +"%Y-%m-%dT%H:%M:%SZ" ) "$@"
@@ -29,11 +35,14 @@ for NODEREF in $( curl -s "${CLUSTER}/_cat/nodes?h=host,node.role,master,name" |
   NODE=$( echo "${NODEREF}" | awk -F '|' '{ print $1 }' )
   NODE_NAME=$( echo "${NODEREF}" | awk -F '|' '{ print $2 }' )
 
-  /bin/echo "To skip node ${NODE_NAME}, enter 's' -- any other key will shut it down for maintenance"
-  read SKIP
-  if [ ${SKIP} = "s" ]
+  if [ ${INTERACTIVE} == true ]
   then
-    continue
+    /bin/echo "To skip node ${NODE_NAME}, enter 's' -- any other key will shut it down for maintenance"
+    read SKIP
+    if [ ${SKIP} == "s" ]
+    then
+      continue
+    fi
   fi
 
   decho "> restarting ${NODE_NAME}"

--- a/share/util/elasticsearch-rolling-restart
+++ b/share/util/elasticsearch-rolling-restart
@@ -3,18 +3,23 @@
 #
 # perform a rolling restart of all data/master nodes in a stable cluster
 #
-# args: [elasticsearch-host:port] -i|--interactive
+# args: [-i|--interactive] [elasticsearch-host:port]
 #
 
 set -e
 set -u
 
-CLUSTER="${1:-localhost:9200}"
-INTERACTIVE="${2:-false}"
-
-if [[ ${2} == "-i" ]] || [[ ${2} == "--interactive" ]]
+if [ $# -eq 0 ]
+then
+  CLUSTER="localhost:9200"
+  INTERACTIVE=false
+elif [[ $1 == "-i" || $1 = "--interactive" ]]
 then
   INTERACTIVE=true
+  CLUSTER="${2:-localhost:9200}"
+else
+  INTERACTIVE=false
+  CLUSTER="${1:-localhost:9200}"
 fi
 
 function decho {


### PR DESCRIPTION
For the rolling restart script, this adds the ability to skip a node. This is especially handy if the script originally got interrupted and/or some nodes don't need maintenance.
