### PR TITLE
Adds ability to specify input codec as a manifest property.

### DIFF
--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -49,6 +49,8 @@ properties:
   logstash_parser.elasticsearch_index_type:
     description: "The specific, dynamic index type name to write events to."
     default: "%{@type}"
+  logstash_parser.input_codec:
+    description: "The input codec and configuration used for input data."
   logstash_parser.use_local_elasticsearch:
     description: "Run a local elasticsearch client node"
     default: true

--- a/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
+++ b/jobs/log_parser/templates/config/input_redis_and_output_elasticsearch.conf.erb
@@ -7,6 +7,9 @@ input {
         data_type => "list"
         key => "<%= p("redis.key") %>"
         threads => 8
+        <% if p("logstash_parser.input_codec") %>
+        codec => <%= p("logstash_parser.input_codec") %>
+        <% end %>
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Derwei Chan dchan@pivotal.io

This allows us to enable the multiline codec.
