### PR TITLE
Upgrade to logstash 1.5.0 rc3

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -163,3 +163,19 @@ elasticsearch/elasticsearch-1.5.1.tar.gz:
   object_id: 93b93692-d68a-44e7-86d7-dabe5e13f8d5
   sha: b3863a63d265486332042246bf1c002b3a70b46f
   size: 28183803
+logstash/logstash-1.5.0-rc3.tar.gz:
+  object_id: 28abdf91-406a-4d3d-b5c7-99ac2f0e6e79
+  sha: d535f066c2e829b40fc4d145ddc6a2f723bf913a
+  size: 87458848
+logstash/logstash-filter-alter-0.1.6.gem:
+  object_id: d96edc4c-ffdd-4fc8-9bae-1dc243b2e074
+  sha: e2cadce7e3d145c791087832c4f647f451f5027e
+  size: 8704
+logstash/logstash-filter-translate-0.1.9.gem:
+  object_id: 9848212e-40a3-4f46-b40d-407f5b94d2c3
+  sha: 65e437fd64202ff879990d7c7963f3f7b4e50c17
+  size: 10240
+logstash/logstash-input-relp-0.1.5.gem:
+  object_id: cf9789c1-f2dc-43ca-b0fa-8c53f1346184
+  sha: eb4c73ac65bc39ea3d51b8473dfe69d263694fa9
+  size: 11776

--- a/examples/bosh-lite.yml
+++ b/examples/bosh-lite.yml
@@ -144,6 +144,11 @@ jobs:
 #      key: "logstash-restorer"
 
 properties: 
+  api:
+    port: 80
+  kibana:
+   elasticsearch: 127.0.0.1:9200
+   port: 5601
   elasticsearch:
     host: 10.244.2.2
     cluster_name: logsearch--bosh-lite

--- a/examples/micro-logsearch-bosh-lite.yml
+++ b/examples/micro-logsearch-bosh-lite.yml
@@ -48,6 +48,11 @@ jobs:
     - 10.244.2.26
   persistent_disk: 1024
 properties: 
+  api:
+    port: 80
+  kibana:
+   elasticsearch: 127.0.0.1:9200
+   port: 5601
   elasticsearch:
     host: 10.244.2.26
     cluster_name: micro-logsearch

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -6,7 +6,7 @@ set -u # report the usage of uninitialized variables
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
 mkdir $BOSH_INSTALL_TARGET/logstash
-tar -xzf logstash/logstash-1.5.0.rc2.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
+tar -xzf logstash/logstash-1.5.0-rc3.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
 
 # Setup Java so we can run logstash/bin/plugin install
 JAVA_HOME=/var/vcap/packages/java8
@@ -14,9 +14,9 @@ PATH=$PATH:/var/vcap/packages/java8/bin
 
 # Install plugins
 
-# After https://github.com/elastic/logstash/issues/2674 gets resolved, install plugins from .gem files like this:
-# $BOSH_INSTALL_TARGET/logstash/bin/plugin install $BOSH_COMPILE_TARGET/logstash/logstash-filter-alter-0.1.5.gem
+$BOSH_INSTALL_TARGET/logstash/bin/plugin install \
+$BOSH_COMPILE_TARGET/logstash/logstash-filter-alter-0.1.6.gem \
+$BOSH_COMPILE_TARGET/logstash/logstash-filter-translate-0.1.9.gem \
+$BOSH_COMPILE_TARGET/logstash/logstash-input-relp-0.1.5.gem
 
-# For now, we have to install from rubygems; meaning that the compilation VMs must have 'net access
-$BOSH_INSTALL_TARGET/logstash/bin/plugin install logstash-filter-alter logstash-filter-translate logstash-input-relp
 

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -3,7 +3,11 @@ name: logstash
 dependencies: 
   - java8
 files: 
-  # http://download.elasticsearch.org/logstash/logstash/logstash-1.5.0.rc2.tar.gz
-  - logstash/logstash-1.5.0.rc2.tar.gz
-  # https://rubygems.org/downloads/logstash-filter-alter-0.1.5.gem
-  - logstash/logstash-filter-alter-0.1.5.gem
+  # https://download.elastic.co/logstash/logstash/logstash-1.5.0-rc3.tar.gz
+  - logstash/logstash-1.5.0-rc3.tar.gz
+  # https://rubygems.org/downloads/logstash-filter-alter-0.1.6.gem
+  - logstash/logstash-filter-alter-0.1.6.gem
+  # https://rubygems.org/downloads/logstash-filter-translate-0.1.9.gem 
+  - logstash/logstash-filter-translate-0.1.9.gem
+  # https://rubygems.org/downloads/logstash-input-relp-0.1.5.gem
+  - logstash/logstash-input-relp-0.1.5.gem


### PR DESCRIPTION
Upgrades logstash from 1.5.0-rc2 to logstash 1.5.0-rc3, which:
- Has performance improvements
- Allows plugins to be installed from local gem files (meaning tha the logstash package compilation should no longer need internet access; and is marginally faster)
