### PR TITLE
Add support for dynamic logstash plugins

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -59,5 +59,5 @@ properties:
     description: "Additional options to append to elasticsearch's logging.yml (YAML format)."
     default: ~
   elasticsearch.plugins:
-    description: "Plugins to run elasticsearch with (array[] = { plugin-name: install-source }"
+    description: "Plugins to run elasticsearch with (array[] = { plugin-name: install-source }; e.g. [ { kopf: 'lmenezes/elasticsearch-kopf' } ])"
     default: []

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -53,7 +53,7 @@ properties:
     description: "Run a local elasticsearch client node"
     default: true
   logstash_parser.plugins:
-    description: "Plugins to run logstash with (array[] = { plugin-name: install-source }"
+    description: "Plugins to run logstash with (array[] = { plugin-name: install-source }; e.g. [ { logstash-filter-cityindex-acctlookup: 'https://s3.amazonaws.com/.../logstash-filter-cityindex-acctlookup-1.2.9.gem' } ])"
     default: []
 
   elasticsearch.host:

--- a/jobs/log_parser/spec
+++ b/jobs/log_parser/spec
@@ -52,6 +52,9 @@ properties:
   logstash_parser.use_local_elasticsearch:
     description: "Run a local elasticsearch client node"
     default: true
+  logstash_parser.plugins:
+    description: "Plugins to run logstash with (array[] = { plugin-name: install-source }"
+    default: []
 
   elasticsearch.host:
     description: IP / DNS of elasticsearch http endpoint

--- a/jobs/log_parser/templates/bin/log_parser_ctl
+++ b/jobs/log_parser/templates/bin/log_parser_ctl
@@ -15,6 +15,10 @@ export LOGSTASH_WORKERS=`grep -c ^processor /proc/cpuinfo`
 export LOGSTASH_WORKERS=<%= p('logstash_parser.workers') %>
 <% end %>
 
+LOCAL_PLUGINS_DIR=/var/vcap/packages/logstash/logstash/vendor/bundle/jruby/1.9/gems
+LOCAL_PLUGINS_NAME_LIST=$( cat /var/vcap/packages/logstash/plugins-default.list | tr "\n" ' ' )
+LOCAL_PLUGINS_NAME_LIST=" ${LOCAL_PLUGINS_NAME_LIST} <%= p('logstash_parser.plugins').map { | plugin | plugin[0] }.join(' ') %> "
+
 case $1 in
 
   start)
@@ -22,6 +26,27 @@ case $1 in
 
     # store this processes pid in $PIDFILE, since the exec below doesn't daemonize
     echo $$ > $PIDFILE
+
+    # install new plugins
+    <% p('logstash_parser.plugins').each do | plugin | pname, psource = plugin.first %>
+      if ! ls ${LOCAL_PLUGINS_DIR}/<%= pname %>-* 1> /dev/null 2>&1 ; then
+        <% if psource =~ /:\/\// %>
+          wget -O '<%= psource %>.gem' '<% psource %>'
+          /var/vcap/packages/logstash/logstash/bin/plugin install '<%= psource %>.gem'
+          rm '<%= psource %>.gem'
+        <% else %>
+          /var/vcap/packages/logstash/logstash/bin/plugin install '<%= pname %>'
+        <% end %>
+      fi
+    <% end %>
+
+    # remove old plugins
+
+    for LOCAL_PLUGIN_NAME in $( /var/vcap/packages/logstash/logstash/bin/plugin list ) ; do
+      if ! [[ "${LOCAL_PLUGINS_NAME_LIST}" =~ (^| )$LOCAL_PLUGIN_NAME($| ) ]] ; then
+        /var/vcap/packages/logstash/logstash/bin/plugin uninstall "${LOCAL_PLUGIN_NAME}"
+      fi
+    done
 
     # construct a complete config file from all the fragments
     cat ${JOB_DIR}/config/input_redis_and_output_elasticsearch.conf > ${JOB_DIR}/config/logstash.conf

--- a/jobs/log_parser/templates/bin/log_parser_ctl
+++ b/jobs/log_parser/templates/bin/log_parser_ctl
@@ -17,7 +17,7 @@ export LOGSTASH_WORKERS=<%= p('logstash_parser.workers') %>
 
 LOCAL_PLUGINS_DIR=/var/vcap/packages/logstash/logstash/vendor/bundle/jruby/1.9/gems
 LOCAL_PLUGINS_NAME_LIST=$( cat /var/vcap/packages/logstash/plugins-default.list | tr "\n" ' ' )
-LOCAL_PLUGINS_NAME_LIST=" ${LOCAL_PLUGINS_NAME_LIST} <%= p('logstash_parser.plugins').map { | plugin | plugin[0] }.join(' ') %> "
+LOCAL_PLUGINS_NAME_LIST=" ${LOCAL_PLUGINS_NAME_LIST} <%= p('logstash_parser.plugins').map { | plugin | plugin.first[0] }.join(' ') %> "
 
 case $1 in
 

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -15,8 +15,9 @@ PATH=$PATH:/var/vcap/packages/java8/bin
 # Install plugins
 
 $BOSH_INSTALL_TARGET/logstash/bin/plugin install \
-$BOSH_COMPILE_TARGET/logstash/logstash-filter-alter-0.1.6.gem \
-$BOSH_COMPILE_TARGET/logstash/logstash-filter-translate-0.1.9.gem \
-$BOSH_COMPILE_TARGET/logstash/logstash-input-relp-0.1.5.gem
+  $BOSH_COMPILE_TARGET/logstash/logstash-filter-alter-0.1.6.gem \
+  $BOSH_COMPILE_TARGET/logstash/logstash-filter-translate-0.1.9.gem \
+  $BOSH_COMPILE_TARGET/logstash/logstash-input-relp-0.1.5.gem
 
-
+$BOSH_INSTALL_TARGET/logstash/bin/plugin list \
+  > $BOSH_INSTALL_TARGET/plugins-default.list


### PR DESCRIPTION
So, nearly the same as we handle elasticsearch plugins:

```
properties:
  # values are arrays, first being the installed plugin name, second being install source
  logstash_parser.plugins:
    # one of the built-in, official plugins
    - { "logstash-filter-punct" : "logstash-filter-punct" }
    # an internal plugin
    - { "cityindex-logstash-filter-acctlookup" : "https://s3.amazonaws.com/.../cityindex-logstash-filter-acctlookup-1.2.9.gem" }
```
