### PR TITLE
Remote logsearch-latest.yml

### DIFF
--- a/releases/logsearch-latest.yml
+++ b/releases/logsearch-latest.yml
@@ -1,1 +1,0 @@
-logsearch-.yml


### PR DESCRIPTION
Remove symbolic link as now `bosh upload release` will upload the lastest one.
Btw the link was wrong anyway.
