### PR TITLE
Avoid indices literally named %{@type}

### DIFF
--- a/jobs/log_parser/templates/config/filters_pre.conf.erb
+++ b/jobs/log_parser/templates/config/filters_pre.conf.erb
@@ -45,6 +45,16 @@ filter {
     }
 
     #
+    # avoid bad interpolations, like `%{type}` when its missing
+    #
+
+    if [@type] == "" {
+        mutate {
+            add_field => [ "@type", "unknown" ]
+        }
+    }
+
+    #
     # ignore particularly useless lines
     #
 


### PR DESCRIPTION
Abnormal URIs are inconvenient, and `unknown` makes more sense than if you happen to forget to tag a message.

Issue #65
