### PR TITLE
Support logstash filters on ingestors for naive filtering and throttling

### DIFF
--- a/jobs/ingestor_archiver/spec
+++ b/jobs/ingestor_archiver/spec
@@ -21,6 +21,9 @@ properties:
     description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
     default: "NONE"
 
+  logstash_ingestor.filters:
+    description: Filters to execute on the ingestors
+    default: ""
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_archiver/templates/config/archiver_to_redis.conf.erb
+++ b/jobs/ingestor_archiver/templates/config/archiver_to_redis.conf.erb
@@ -17,6 +17,8 @@ filter {
             add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
         }
     <% end %>
+
+    <%= p('logstash_ingestor.filters') %>
 }
 
 output {

--- a/jobs/ingestor_lumberjack/spec
+++ b/jobs/ingestor_lumberjack/spec
@@ -17,6 +17,9 @@ properties:
     description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
     default: "NONE"
 
+  logstash_ingestor.filters:
+    description: Filters to execute on the ingestors
+    default: ""
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
+++ b/jobs/ingestor_lumberjack/templates/config/lumberjack_to_redis.conf.erb
@@ -13,18 +13,20 @@ filter {
 		add_field => [ "@source.path", "%{file}" ]
 		add_field => [ "@source.offset", "%{offset}" ]
 		remove_field => [ "host", "file", "offset" ]
-
-	    <% if 'DEBUG' == p('logstash.metadata_level') %>
-			add_field => [ "@ingestor[service]", "lumberjack" ]
-			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
-		<% end %>
 	}
 
-    <% if 'DEBUG' == p('logstash.metadata_level') %>
+  <% if 'DEBUG' == p('logstash.metadata_level') %>
+    mutate {
+			add_field => [ "@ingestor[service]", "lumberjack" ]
+			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
+    }
+
 		ruby {
 			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
 		}
 	<% end %>
+
+  <%= p('logstash_ingestor.filters') %>
 }
 				
 output {

--- a/jobs/ingestor_relp/spec
+++ b/jobs/ingestor_relp/spec
@@ -15,6 +15,9 @@ properties:
     description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
     default: "NONE"
 
+  logstash_ingestor.filters:
+    description: Filters to execute on the ingestors
+    default: ""
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
+++ b/jobs/ingestor_relp/templates/config/relp_to_redis.conf.erb
@@ -6,8 +6,8 @@ input {
 	}
 }
 
-<% if 'DEBUG' == p('logstash.metadata_level') %>
-	filter {
+filter {
+  <% if 'DEBUG' == p('logstash.metadata_level') %>
 		mutate {
 			add_field => [ "@ingestor[service]", "relp" ]
 			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
@@ -16,8 +16,10 @@ input {
 		ruby {
 			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
 		}
-	}
-<% end %>
+  <% end %>
+
+  <%= p('logstash_ingestor.filters') %>
+}
 			
 output {
 	<% if p("logstash_ingestor.debug") %>

--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -17,6 +17,9 @@ properties:
     description: "Whether to include additional metadata throughout the event lifecycle. NONE = disabled, DEBUG = fully enabled"
     default: "NONE"
 
+  logstash_ingestor.filters:
+    description: Filters to execute on the ingestors
+    default: ""
   logstash_ingestor.debug:
     description: Debug level logging
     default: false

--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -24,8 +24,8 @@ input {
 	<% end %>
 }
 
-<% if 'DEBUG' == p('logstash.metadata_level') %>
-	filter {
+filter {
+  <% if 'DEBUG' == p('logstash.metadata_level') %>
 	    mutate {
 	        rename => [ "host", "@ingestor.remote_host" ]
 	        rename => [ "sslsubject", "@ingestor.sslsubject" ]
@@ -37,8 +37,10 @@ input {
 		ruby {
 			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
 		}
-	}
-<% end %>
+  <% end %>
+
+  <%= p('logstash_ingestor.filters') %>
+}
 
 output {
 	<% if p("logstash_ingestor.debug") %>


### PR DESCRIPTION
If people really want throttling, they can configure it with the `logstash_ingestor.filters` property which operates identically to the parsers, just on the ingestors. The usage should obviously be kept to a minimum given parsers are the more scalable option. More intended to be a temporary stopgap to something causing the later services to topple.

Issue #4
