### PR TITLE
use plain text file for logsearch-latest.yml 

### DIFF
--- a/releases/logsearch-latest.yml
+++ b/releases/logsearch-latest.yml
@@ -1,1 +1,82 @@
-logsearch-20.yml
+---
+packages:
+- name: elasticsearch
+  version: eca0f2f78fb671a7c22d4baef2542ad68e9b71f8
+  fingerprint: eca0f2f78fb671a7c22d4baef2542ad68e9b71f8
+  sha1: ea2184f33fda9e1ea63dd73ff53c36a2eee618f7
+  dependencies: []
+- name: java8
+  version: 0ae49bb225b4b74e6d4f9cab3681ebd2f725b9aa
+  fingerprint: 0ae49bb225b4b74e6d4f9cab3681ebd2f725b9aa
+  sha1: 45359766f7efc2de7ea0df4ba8736b81a9abeb38
+  dependencies: []
+- name: kibana
+  version: 4fff443e15e6003b9796bb29b861306ce399268c
+  fingerprint: 4fff443e15e6003b9796bb29b861306ce399268c
+  sha1: 2cbf11699b09dd703d9acde7b433f861cc9248ea
+  dependencies: []
+- name: logstash
+  version: a8d0f624efe29d05f223d4a16960e709cc442c6e
+  fingerprint: a8d0f624efe29d05f223d4a16960e709cc442c6e
+  sha1: b9d706251584cc192df38c424f592c34a9f73b1f
+  dependencies:
+  - java8
+- name: nginx
+  version: 07fa264094f0ebb55bcc9990578d9cc159748dc0
+  fingerprint: 07fa264094f0ebb55bcc9990578d9cc159748dc0
+  sha1: 8b1625f2f49e08ea2649ed0694b655fc0c10ab13
+  dependencies: []
+- name: redis
+  version: cd861700c83a544b6d0bba3b620017d22cf0d726
+  fingerprint: cd861700c83a544b6d0bba3b620017d22cf0d726
+  sha1: eb71fe4bae7331bdf281783df22603518f12626f
+  dependencies: []
+jobs:
+- name: api
+  version: c83ed5f537f3edac5b6de98b82813cc46389dd3c
+  fingerprint: c83ed5f537f3edac5b6de98b82813cc46389dd3c
+  sha1: 8c3c5f8057d4be341f22a6a60fcf6e7fd62813b8
+- name: archiver
+  version: 2bcf9488b9be2f5f9fec911b16cb5c5bc3a9fd94
+  fingerprint: 2bcf9488b9be2f5f9fec911b16cb5c5bc3a9fd94
+  sha1: bdfa4f9285c18bd9464a19319d96d3d7aa4bd321
+- name: elasticsearch
+  version: 8fd6976d17994beffcfc623fad675e990d53f2c9
+  fingerprint: 8fd6976d17994beffcfc623fad675e990d53f2c9
+  sha1: f0c899b8fb256b849f6ba2ade7fe4a9b70165857
+- name: ingestor_archiver
+  version: 551e26ba32995f118d2cb6811b85f1437037b8a3
+  fingerprint: 551e26ba32995f118d2cb6811b85f1437037b8a3
+  sha1: df28dbf385d2fe205555ab50f85196eaddbd937a
+- name: ingestor_lumberjack
+  version: ce8645b9cbeeae75a2373ebfaee3d39f4bb6ef9f
+  fingerprint: ce8645b9cbeeae75a2373ebfaee3d39f4bb6ef9f
+  sha1: fd9aa83d07bc4b00423dc477c26e08a8a612f10a
+- name: ingestor_relp
+  version: b7460e2f6b839bf8c6db0f5a7590a3e870bdfc16
+  fingerprint: b7460e2f6b839bf8c6db0f5a7590a3e870bdfc16
+  sha1: a5ff9ffaca710cbc432ee121a22ee346524415c0
+- name: ingestor_syslog
+  version: 287c712ce976d111d75e6bdc427bd464bbc02a3b
+  fingerprint: 287c712ce976d111d75e6bdc427bd464bbc02a3b
+  sha1: c772b4cd0cfe8f1b4a6b1376ea1a084a8d273df1
+- name: kibana
+  version: 2c92bf9539d1898f5ff673cf6e2675ec1aaffafd
+  fingerprint: 2c92bf9539d1898f5ff673cf6e2675ec1aaffafd
+  sha1: dfafe1ac6a2df5554b83bf580869637ecce846cc
+- name: log_parser
+  version: f0cce9efe12bb6a4cf56221b0f86f076e833aa85
+  fingerprint: f0cce9efe12bb6a4cf56221b0f86f076e833aa85
+  sha1: d561cf33a7a03c79899fd300a65530eb999d5ded
+- name: queue
+  version: 44867e5b6d60939104bb32dcfecc7f247c03b0a0
+  fingerprint: 44867e5b6d60939104bb32dcfecc7f247c03b0a0
+  sha1: 85bbacab2205616cc0bacea961a6df89fae98678
+license:
+  version: 45ba225fe5790e0633fb9a8e20be9efeea888f51
+  fingerprint: 45ba225fe5790e0633fb9a8e20be9efeea888f51
+  sha1: 065103911af70b44df428eee52b3400417adb630
+commit_hash: da7806ca
+uncommitted_changes: true
+name: logsearch
+version: '20'


### PR DESCRIPTION
With v20, 

```
± |develop ✓| → bosh upload release releases/logsearch-latest.yml

Verifying release...
File exists and readable                                     OK
Extract tarball                                              FAILED
```

It appears that having logsearch-latest.yml as a symlink is the root cause, since 

```
bosh upload release releases/logsearch-20.yml
```

works.

It seems we need to use plain text for logsearch-latest.yml as a symbol link cannot work with bosh. with this change, anyone can always upload release by:

```
bosh upload release releases/logsearch-latest.yml
```

and we should keep updating the file whenever a new release is available. 
