### PR TITLE
Update to Kibana 4.1.1, ES 1.6.0 and Logstash 1.5.2

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -43,3 +43,7 @@ logstash/logstash-1.5.0.tar.gz:
   object_id: 5dbd902b-49d4-40e5-a3b1-a240c5af017f
   sha: 9729c2d31fddaabdd3d8e94c34a6d1f61d57f94a
   size: 87008665
+elasticsearch/elasticsearch-1.6.0.tar.gz:
+  object_id: c305d75d-a100-4dfd-a619-b5c4ee31d0e9
+  sha: cb8522f5d3daf03ef96ed533d027c0e3d494e34b
+  size: 28401477

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -51,3 +51,7 @@ logstash/logstash-1.5.2.tar.gz:
   object_id: 36249fab-dcf7-45b1-9ecd-e2a842b93c9f
   sha: 92e4ce646ca6a1868bac56def5ddf096349ec0a6
   size: 91217160
+kibana/kibana-4.1.1-linux-x64.tar.gz:
+  object_id: c08909df-55f0-400a-bac6-399e309d70c0
+  sha: d43e039adcea43e1808229b9d55f3eaee6a5edb9
+  size: 11676499

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -43,3 +43,7 @@ logstash/logstash-1.5.0.tar.gz:
   object_id: 5dbd902b-49d4-40e5-a3b1-a240c5af017f
   sha: 9729c2d31fddaabdd3d8e94c34a6d1f61d57f94a
   size: 87008665
+logstash/logstash-1.5.2.tar.gz:
+  object_id: 36249fab-dcf7-45b1-9ecd-e2a842b93c9f
+  sha: 92e4ce646ca6a1868bac56def5ddf096349ec0a6
+  size: 91217160

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -5,8 +5,8 @@ set -u # report the usage of uninitialized variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
-tar xzf elasticsearch/elasticsearch-1.5.2.tar.gz
-cp -R elasticsearch-1.5.2/* $BOSH_INSTALL_TARGET
+tar xzf elasticsearch/elasticsearch-1.6.0.tar.gz
+cp -R elasticsearch-1.6.0/* $BOSH_INSTALL_TARGET
 
 #Plugins
 

--- a/packages/elasticsearch/spec
+++ b/packages/elasticsearch/spec
@@ -2,6 +2,6 @@
 name: elasticsearch
 dependencies: [] # no compile dependencies
 files: 
-  # https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.5.2.tar.gz
-  - elasticsearch/elasticsearch-1.5.2.tar.gz
+  # https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz
+  - elasticsearch/elasticsearch-1.6.0.tar.gz
   - elasticsearch/kibana-3.1.0.tar.gz

--- a/packages/kibana/packaging
+++ b/packages/kibana/packaging
@@ -5,4 +5,4 @@ set -u # report the usage of uninitialized variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
-tar -xzf kibana/kibana-4.0.1-linux-x64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1
+tar -xzf kibana/kibana-4.1.1-linux-x64.tar.gz -C $BOSH_INSTALL_TARGET --strip-components 1

--- a/packages/kibana/spec
+++ b/packages/kibana/spec
@@ -2,5 +2,5 @@
 name: kibana
 dependencies: []
 files: 
-  # https://download.elasticsearch.org/kibana/kibana/kibana-4.0.1-linux-x64.tar.gz
-  - kibana/kibana-4.0.1-linux-x64.tar.gz
+  # https://download.elasticsearch.org/kibana/kibana/kibana-4.1.1-linux-x64.tar.gz
+  - kibana/kibana-4.1.1-linux-x64.tar.gz

--- a/packages/logstash/packaging
+++ b/packages/logstash/packaging
@@ -6,7 +6,7 @@ set -u # report the usage of uninitialized variables
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
 mkdir $BOSH_INSTALL_TARGET/logstash
-tar -xzf logstash/logstash-1.5.0.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
+tar -xzf logstash/logstash-1.5.2.tar.gz -C $BOSH_INSTALL_TARGET/logstash --strip-components 1
 
 # Setup Java so we can run logstash/bin/plugin install
 JAVA_HOME=/var/vcap/packages/java8

--- a/packages/logstash/spec
+++ b/packages/logstash/spec
@@ -3,8 +3,8 @@ name: logstash
 dependencies: 
   - java8
 files: 
-  # https://download.elastic.co/logstash/logstash/logstash-1.5.0.tar.gz
-  - logstash/logstash-1.5.0.tar.gz
+  # https://download.elastic.co/logstash/logstash/logstash-1.5.2.tar.gz
+  - logstash/logstash-1.5.2.tar.gz
   # https://rubygems.org/downloads/logstash-filter-alter-0.1.6.gem
   - logstash/logstash-filter-alter-0.1.6.gem
   # https://rubygems.org/downloads/logstash-filter-translate-0.1.9.gem 


### PR DESCRIPTION
Updates to Kibana 4.1.1 ( [what's new](https://www.elastic.co/guide/en/kibana/current/whats-new.html) ) 

Requires ES 1.6.0 and logstash 1.5.2
