### PR TITLE
Allows setting es job templates and properties through stub

### DIFF
--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -27,6 +27,7 @@ properties:
   api:
     elasticsearch_host: (( jobs.api.networks.default.static_ips.[0] ":9200"))
   elasticsearch:
+    <<: (( merge ))
     log_level: DEBUG
     host: (( jobs.api.networks.default.static_ips.[0] "," jobs.elasticsearch_persistent.networks.default.static_ips.[0] "," jobs.elasticsearch_autoscale.networks.default.static_ips.[0]))
     cluster_name: (( name ))

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -7,6 +7,9 @@ meta:
       - name: elasticsearch
       - name: api
       - name: kibana
+    elasticsearch:
+      templates:
+      - name: elasticsearch
 
 networks: (( merge ))
 name: (( merge ))
@@ -94,8 +97,7 @@ jobs:
 
 - name: elasticsearch_persistent
   release: logsearch
-  templates:
-  - name: elasticsearch
+  templates: (( merge || meta.jobs.elasticsearch.templates ))
   update:
     serial: true
   instances: 1
@@ -111,8 +113,7 @@ jobs:
 
 - name: elasticsearch_autoscale
   release: logsearch
-  templates:
-  - name: elasticsearch
+  templates: (( merge || meta.jobs.elasticsearch.templates ))
   update:
     serial: true
   instances: 1


### PR DESCRIPTION
We been working in performing snapshots on ES. For this we mount nfs server on the ES servers. This allow us to collocate templates to the ES jobs in the stub file using spiff. 
