### PR TITLE
ES upgrades & minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Upload the latest logsearch release from [bosh.io](https://bosh.io)...
     $ bosh upload release https://bosh.io/d/github.com/logsearch/logsearch-boshrelease
 
 If you are using [bosh-lite](https://github.com/cloudfoundry/bosh-lite), you can
-get started with our sample manifest, [`bosh-lite.yml`](./examples/bosh-lite.yml)...
+get started with our sample manifest, [`bosh-lite.yml`](./templates/bosh-lite.yml)...
 
-    $ bosh -d examples/bosh-lite.yml deploy
+    $ bosh -d templates/bosh-lite.yml deploy
 
 For more details, review the [`docs/`](http://www.logsearch.io/docs/boshrelease/)
 or raise an issue if you run into a bug.
@@ -33,9 +33,9 @@ or raise an issue if you run into a bug.
 ## Testing
 
 To run a sanity test which ships some sample logs, parses, and then queries them,
-use the pre-configured `test_e2e_errand` errand from `examples/bosh-lite.yml`...
+use the pre-configured `test_e2e_errand` errand from `templates/bosh-lite.yml`...
 
-    $ bosh -d examples/bosh-lite.yml run errand test_e2e_errand
+    $ bosh -d templates/bosh-lite.yml run errand test_e2e_errand
     ...snip...
     ==> Validating results...
     SUCCESS

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -55,3 +55,7 @@ kibana/kibana-4.1.1-linux-x64.tar.gz:
   object_id: c08909df-55f0-400a-bac6-399e309d70c0
   sha: d43e039adcea43e1808229b9d55f3eaee6a5edb9
   size: 11676499
+elasticsearch/elasticsearch-1.7.1.tar.gz:
+  object_id: 5ba2c3ed-1730-40fc-9646-aafcab7d9c39
+  sha: 0984ae27624e57c12c33d4a559c3ebae25e74508
+  size: 28500556

--- a/jobs/test_e2e_errand/templates/bin/run.erb
+++ b/jobs/test_e2e_errand/templates/bin/run.erb
@@ -15,13 +15,12 @@ export PATH="/var/vcap/packages/java8/bin:$PATH"
 
 [ ! -e /home/vcap/.sincedb ] || rm /home/vcap/.sincedb
 
-echo '' ; echo '==> Checking elastic search health...'
+echo '' ; echo '==> Checking elasticsearch health...'
 
-curl -XGET http://<%= p('test_e2e_errand.elasticsearch_hostport') %>/_cluster/health?pretty 2>/dev/null > curl.out
+ESCOLOR=$( curl -s http://<%= p('test_e2e_errand.elasticsearch_hostport') %>/_cat/health?h=status | tr -d '[:space:]' )
 
-if [[ $(grep '"status" : "red"' curl.out) == "" ]]; then
-  cat curl.out
-  fail 'ElasticSearch is in a bad state, giving up'
+if [[ "green" != "${ESCOLOR}" ]] && [[ "yellow" != "${ESCOLOR}" ]]; then
+  fail "elasticsearch is '${ESCOLOR}' but should be at least yellow - giving up"
 fi
 
 echo '' ; echo '==> Purging existing test data...'
@@ -74,8 +73,7 @@ curl -s -X DELETE '<%= p('test_e2e_errand.elasticsearch_hostport') %>/_all/sampl
 
 echo '' ; echo '==> Ensuring test data was cleaned up...'
 
-curl -s '<%= p('test_e2e_errand.elasticsearch_hostport') %>/_all/sample-logs--repo-commits/_search?size=1024&pretty' > curl.out
-if ! grep '"total" : 0' curl.out > /dev/null 2>&1 ; then
+if ! curl -s '<%= p('test_e2e_errand.elasticsearch_hostport') %>/_all/sample-logs--repo-commits/_search?size=1024' | grep -q '"total":0,' ; then
   fail 'There was still test data present after cleanup...'
 fi
 

--- a/packages/elasticsearch/packaging
+++ b/packages/elasticsearch/packaging
@@ -5,8 +5,8 @@ set -u # report the usage of uninitialized variables
 # $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
 # $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
 
-tar xzf elasticsearch/elasticsearch-1.6.0.tar.gz
-cp -R elasticsearch-1.6.0/* $BOSH_INSTALL_TARGET
+tar xzf elasticsearch/elasticsearch-1.7.1.tar.gz
+cp -R elasticsearch-1.7.1/* $BOSH_INSTALL_TARGET
 
 #Plugins
 

--- a/packages/elasticsearch/spec
+++ b/packages/elasticsearch/spec
@@ -2,6 +2,6 @@
 name: elasticsearch
 dependencies: [] # no compile dependencies
 files: 
-  # https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.6.0.tar.gz
-  - elasticsearch/elasticsearch-1.6.0.tar.gz
+  # https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz
+  - elasticsearch/elasticsearch-1.7.1.tar.gz
   - elasticsearch/kibana-3.1.0.tar.gz


### PR DESCRIPTION
Upgrades elasticsearch to 1.7.1 (from 1.6.0) and logstash to 1.5.3 (from 1.5.2). Also cleans up the e2e test from some prior PRs and fixes some old references in readme.

Waiting on validation before merging...
- [x] e2e
- [x] meta
- [x] cityindex
