### PR TITLE
Improve resource pool by adding dedicated pools for queue & parser

### DIFF
--- a/templates/logsearch-deployment.yml
+++ b/templates/logsearch-deployment.yml
@@ -36,12 +36,6 @@ update:
   max_errors: 1
 
 resource_pools:
-- name: logsearch
-  network: default
-  stemcell: (( meta.stemcell ))
-  cloud_properties: (( merge ))
-  env: (( merge || meta.default_env ))
-
 - name: logsearch_api
   network: default
   stemcell: (( meta.stemcell ))
@@ -58,5 +52,17 @@ resource_pools:
   network: default
   stemcell: (( meta.stemcell ))
   cloud_properties: ~
+  env: (( merge || meta.default_env ))
+
+- name: logsearch_queue
+  network: default
+  stemcell: (( meta.stemcell ))
+  cloud_properties: ~
+  env: (( merge || meta.default_env ))
+
+- name: logsearch_parser
+  network: default
+  stemcell: (( meta.stemcell ))
+  cloud_properties: (( merge ))
   env: (( merge || meta.default_env ))
 

--- a/templates/logsearch-deployment.yml
+++ b/templates/logsearch-deployment.yml
@@ -63,6 +63,6 @@ resource_pools:
 - name: logsearch_parser
   network: default
   stemcell: (( meta.stemcell ))
-  cloud_properties: (( merge ))
+  cloud_properties: ~
   env: (( merge || meta.default_env ))
 

--- a/templates/logsearch-infrastructure-aws.yml
+++ b/templates/logsearch-infrastructure-aws.yml
@@ -48,12 +48,6 @@ compilation:
     instance_type: m1.large
 
 resource_pools:
-  - name: logsearch
-    cloud_properties:
-      availability_zone: (( merge || meta.availability_zone ))
-      instance_type: (( merge || "m1.large" ))
-      elbs: ~
-
   - name: logsearch_api
     cloud_properties:
       availability_zone: (( merge || meta.availability_zone ))
@@ -67,6 +61,18 @@ resource_pools:
       elbs: ~
 
   - name: logsearch_elasticsearch
+    cloud_properties:
+      availability_zone: (( merge || meta.availability_zone ))
+      instance_type: (( merge || "m1.large" ))
+      elbs: ~
+
+  - name: logsearch_queue
+    cloud_properties:
+      availability_zone: (( merge || meta.availability_zone ))
+      instance_type: (( merge || "m1.large" ))
+      elbs: ~
+
+  - name: logsearch_parser
     cloud_properties:
       availability_zone: (( merge || meta.availability_zone ))
       instance_type: (( merge || "m1.large" ))

--- a/templates/logsearch-infrastructure-vsphere.yml
+++ b/templates/logsearch-infrastructure-vsphere.yml
@@ -49,12 +49,6 @@ compilation:
     cpu: 2
 
 resource_pools:
-- name: logsearch
-  cloud_properties:
-    ram: 4096
-    disk: 30000
-    cpu: 2
-
 - name: logsearch_api
   cloud_properties:
     ram: 4096
@@ -68,6 +62,18 @@ resource_pools:
     cpu: 2
 
 - name: logsearch_elasticsearch
+  cloud_properties:
+    ram: 4096
+    disk: 30000
+    cpu: 2
+
+- name: logsearch_queue
+  cloud_properties:
+    ram: 4096
+    disk: 30000
+    cpu: 2
+
+- name: logsearch_parser
   cloud_properties:
     ram: 4096
     disk: 30000

--- a/templates/logsearch-infrastructure-vsphere.yml
+++ b/templates/logsearch-infrastructure-vsphere.yml
@@ -28,8 +28,6 @@ jobs:
     instances: 1
     networks:
       - name: default
-        static_ips: (( static_ips(5) ))
-
   - name: elasticsearch_persistent
     instances: 1
     networks:

--- a/templates/logsearch-infrastructure-warden.yml
+++ b/templates/logsearch-infrastructure-warden.yml
@@ -61,10 +61,6 @@ compilation:
     name: random
 
 resource_pools:
-- name: logsearch
-  cloud_properties:
-    name: random
-
 - name: logsearch_api
   cloud_properties:
     name: random
@@ -74,6 +70,14 @@ resource_pools:
     name: random
 
 - name: logsearch_elasticsearch
+  cloud_properties:
+    name: random
+
+- name: logsearch_queue
+  cloud_properties:
+    name: random
+
+- name: logsearch_parser
   cloud_properties:
     name: random
 

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -74,7 +74,7 @@ jobs:
   templates:
   - name: queue
   instances: 1
-  resource_pool: logsearch
+  resource_pool: logsearch_queue
   persistent_disk: 40960
   networks:
   - name: default
@@ -85,7 +85,7 @@ jobs:
   templates:
   - name: parser
   instances: 1
-  resource_pool: logsearch
+  resource_pool: logsearch_parser
   networks:
   - name: default
     default:


### PR DESCRIPTION
Hello,

During my tests, it was difficult to keep spiff generation along with resource pool tuning for queue & parser(s).

Before, queue & parser(s) were using the same resource pool.
With my pull request, I have created 2 resource pools:
    \* logsearch_queue
    \* logsearch_parser
And remove resource pool logsearch.

Tested on VCloud (Vsphere). I also updated for aws & warden.

I have also fixed vsphere template. In logsearch-jobs.yml, parser jobs are using dynamic IP allocation. But in logsearch-infrastructure-vsphere.yml, it was static allocation.
