### PR TITLE
Curator job: fix new curator job using non existing resource pool

### DIFF
--- a/templates/logsearch-deployment.yml
+++ b/templates/logsearch-deployment.yml
@@ -66,3 +66,9 @@ resource_pools:
   cloud_properties: ~
   env: (( merge || meta.default_env ))
 
+- name: logsearch_curator
+  network: default
+  stemcell: (( meta.stemcell ))
+  cloud_properties: ~
+  env: (( merge || meta.default_env ))
+

--- a/templates/logsearch-infrastructure-aws.yml
+++ b/templates/logsearch-infrastructure-aws.yml
@@ -78,4 +78,10 @@ resource_pools:
       instance_type: (( merge || "m1.large" ))
       elbs: ~
 
+  - name: logsearch_curator
+    cloud_properties:
+      availability_zone: (( merge || meta.availability_zone ))
+      instance_type: (( merge || "m1.large" ))
+      elbs: ~
+
 networks: (( merge ))

--- a/templates/logsearch-infrastructure-vsphere.yml
+++ b/templates/logsearch-infrastructure-vsphere.yml
@@ -77,4 +77,10 @@ resource_pools:
     disk: 30000
     cpu: 2
 
+- name: logsearch_curator
+  cloud_properties:
+    ram: 4096
+    disk: 30000
+    cpu: 2
+
 networks: (( merge ))

--- a/templates/logsearch-infrastructure-warden.yml
+++ b/templates/logsearch-infrastructure-warden.yml
@@ -81,6 +81,10 @@ resource_pools:
   cloud_properties:
     name: random
 
+- name: logsearch_curator
+  cloud_properties:
+    name: random
+
 networks: (( merge || networks_default ))
 networks_default:
 - name: default

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -139,7 +139,7 @@ jobs:
   release: logsearch
   templates:
   - name: curator
-  resource_pool: logsearch
+  resource_pool: logsearch_curator
   networks:
   - name: default
     default:


### PR DESCRIPTION
In latest release (v23.0.0), a new job called curator is using a non existing resource pool. Template generation with spiff is broken.

I have fixed spiff generation by updating the templates.

A new resource pool have been added: logsearch_curator.
