### PR TITLE
Override output block configuration

### DIFF
--- a/jobs/parser/spec
+++ b/jobs/parser/spec
@@ -46,6 +46,8 @@ properties:
     default: [ { plugin: "redis", options : {} } ]
   logstash_parser.outputs:
     description: "The configuration to embed into the logstash outputs section"
+  logstash_parser.output_override:
+    description: "The configuration to override the logstash outputs section"
   logstash_parser.workers:
     description: "The number of worker threads that logstash should use (default: auto = one per CPU)"
     default: auto

--- a/jobs/parser/templates/config/input_and_output.conf.erb
+++ b/jobs/parser/templates/config/input_and_output.conf.erb
@@ -21,7 +21,7 @@ input {
 }
 
 output {
-  <% if p("logstash_parser.output_override") %>
+  <% if p("logstash_parser.output_override", nil) %>
     <%= p('logstash_parser.output_override')  %>
   <% else %>
 

--- a/jobs/parser/templates/config/input_and_output.conf.erb
+++ b/jobs/parser/templates/config/input_and_output.conf.erb
@@ -21,6 +21,10 @@ input {
 }
 
 output {
+  <% if p("logstash_parser.output_override") %>
+    <%= p('logstash_parser.output_override')  %>
+  <% else %>
+
     <% if p("logstash_parser.debug") %>
         stdout {
             codec => "json"
@@ -43,4 +47,6 @@ output {
     }
 
     <%= p('logstash_parser.outputs', '')  %>
+
+  <% end %>
 }

--- a/jobs/parser/templates/config/input_and_output.conf.erb
+++ b/jobs/parser/templates/config/input_and_output.conf.erb
@@ -42,7 +42,7 @@ output {
             document_id => "<%= p('logstash_parser.elasticsearch_document_id') %>"
         <% end %>
         index => "<%= p('logstash_parser.elasticsearch_index') %>"
-        index_type => "<%= p('logstash_parser.elasticsearch_index_type') %>"
+        document_type => "<%= p('logstash_parser.elasticsearch_index_type') %>"
         manage_template => false
     }
 


### PR DESCRIPTION
In Logstash 1.5 there is a new, special field, called [@metadata](https://www.elastic.co/guide/en/logstash/current/event-dependent-configuration.html#metadata). As you can see on example, It gives me ability to alter ES's index name depend on log message type.
But ES output configuration is monolithic by default, so I've used additional `output_override` variable to give me ability to override output block to something like this:

```
properties:
  logstash_parser:
    output_override: |
     if [@metadata][log_type] == "app" {
       elasticsearch {
         host => "127.0.0.1:9200"
         protocol => "http"
         flush_size => 10
         idle_flush_time => 3
         index => "logs-app-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false
       }
     } else {
       elasticsearch {
         host => "127.0.0.1:9200"
         protocol => "http"
         flush_size => 10
         idle_flush_time => 3
         index => "logs-cf-%{+YYYY.MM.dd}"
         document_type => "%{@type}"
         manage_template => false
       }
     }
```

Would do you like it?
