### PR TITLE
Cleanup syslog fields

### DIFF
--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -25,9 +25,9 @@ input {
 }
 
 filter {
-	#Store host as @ingestor.remote_host
+	#Store host as @shipper.host
 	mutate {
-		add_field => { "[@ingestor][remote_host]" => "%{host}" }
+		add_field => { "[@shipper][host]" => "%{host}" }
 	}
 	mutate {
 		remove_field => [ "host" ]

--- a/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/syslog_to_redis.conf.erb
@@ -13,7 +13,7 @@ input {
 	<% end %>
 
 	<% if_p("logstash_ingestor.syslog_tls.port") do | port | %>
-    tcp {
+	tcp {
 		add_field => [ "type", "syslog" ]
 		host => "0.0.0.0"
 		port => "<%= port %>"
@@ -25,21 +25,27 @@ input {
 }
 
 filter {
-  <% if 'DEBUG' == p('logstash.metadata_level') %>
-	    mutate {
-	        rename => [ "host", "@ingestor.remote_host" ]
-	        rename => [ "sslsubject", "@ingestor.sslsubject" ]
+	#Store host as @ingestor.remote_host
+	mutate {
+		add_field => { "[@ingestor][remote_host]" => "%{host}" }
+	}
+	mutate {
+		remove_field => [ "host" ]
+	}
+	<% if 'DEBUG' == p('logstash.metadata_level') %>
+	mutate {
+		add_field => { "[@ingestor][service]" => "syslog" }
+		add_field => { "[@ingestor][job]" => "<%= name %>/<%= index %>" }
+	}
+	ruby {
+		code => "event['@ingestor']['timestamp'] = Time.now.iso8601(3)"
+	}
+	<% end %>
 
-			add_field => [ "@ingestor[service]", "syslog" ]
-			add_field => [ "@ingestor[job]", "<%= name %>/<%= index %>" ]
-	    }
-
-		ruby {
-			code => "event['@ingestor[timestamp]'] = Time.now.iso8601(3)"
-		}
-  <% end %>
-
-  <%= p('logstash_ingestor.filters') %>
+	#
+	# Injected custom filters below from logstash_inject.filters manifest property
+	#
+	<%= p('logstash_ingestor.filters') %>
 }
 
 output {

--- a/src/logsearch-filters-common/.gitignore
+++ b/src/logsearch-filters-common/.gitignore
@@ -1,1 +1,2 @@
 vendor/logstash
+vendor/logstash*

--- a/src/logsearch-filters-common/src/logstash-filters/snippets/syslog_standard.conf
+++ b/src/logsearch-filters-common/src/logstash-filters/snippets/syslog_standard.conf
@@ -14,17 +14,15 @@ if !("fail/syslog_standard/_grokparsefailure" in [tags]) {
         timezone => "UTC"
     }
 
-    # hostname: handle syslog configurations where hostname is localhost
+    # Populate @source.host
     if ([syslog_hostname] == "localhost" ) {
-        grok {
-            match => { "[@ingestor][received_from]" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
-            overwrite => [ "syslog_hostname", "syslog_port" ]
-            tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_hostname"]
+        mutate {
+           add_field => [ "[@source][host]", "%{[@ingestor][received_from]}" ]
         }
-    }
-
-    mutate {
-        replace => [ "[@source][host]", "%{syslog_hostname}" ]
+    } else {
+        mutate {
+            add_field => [ "[@source][host]", "%{syslog_hostname}" ]
+        }
     }
 
     mutate {

--- a/src/logsearch-filters-common/src/logstash-filters/snippets/syslog_standard.conf
+++ b/src/logsearch-filters-common/src/logstash-filters/snippets/syslog_standard.conf
@@ -2,13 +2,11 @@
 
 grok {
     match => { "@message" => "(?:%{INT:syslog6587_msglen} )?<%{POSINT:syslog_pri}>(?:%{NONNEGINT:syslog5424_ver} )?(?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:syslog_timestamp}) %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?(:)? %{GREEDYDATA:syslog_message}" }
-    add_field => [ "received_at", "%{@timestamp}" ]
-    add_field => [ "received_from", "%{host}" ]
     add_tag => [ "syslog_standard" ]
-    tag_on_failure => ["_grokparsefailure-syslog_standard"]
+    tag_on_failure => ["fail/syslog_standard/_grokparsefailure"]
 }
 
-if !("_grokparsefailure-syslog_standard" in [tags]) {
+if !("fail/syslog_standard/_grokparsefailure" in [tags]) {
     syslog_pri { }
 
     date {
@@ -19,25 +17,19 @@ if !("_grokparsefailure-syslog_standard" in [tags]) {
     # hostname: handle syslog configurations where hostname is localhost
     if ([syslog_hostname] == "localhost" ) {
         grok {
-            match => { "received_from" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
+            match => { "[@ingestor][received_from]" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
             overwrite => [ "syslog_hostname", "syslog_port" ]
-            tag_on_failure => [ "_grokparsefailure-syslog_standard-hostname"]
+            tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_hostname"]
         }
     }
 
     mutate {
-        replace => [ "@source.host", "%{syslog_hostname}" ]
+        replace => [ "[@source][host]", "%{syslog_hostname}" ]
     }
 
     mutate {
         convert => [ "syslog5424_ver", "integer" ]
         convert => [ "syslog6587_msglen", "integer" ]
-        remove_field => [
-            #"syslog_pri",
-            "syslog_hostname",
-            "syslog_port",
-            "syslog_timestamp"
-        ]
     }
 
     if [syslog5424_ver] == 1 {
@@ -48,7 +40,7 @@ if !("_grokparsefailure-syslog_standard" in [tags]) {
             overwrite => [
                 "syslog_message"
             ]
-            tag_on_failure => [ "_grokparsefailure-syslog_standard-5424" ]
+            tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_standard-5424" ]
         }
 
         # structured-data
@@ -58,10 +50,10 @@ if !("_grokparsefailure-syslog_standard" in [tags]) {
                 remove_field => [
                     "syslog_sd"
                 ]
-                tag_on_failure => [ "_grokparsefailure-syslog_standard-5424/sds" ]
+                tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_standard-5424/sds" ]
             }
 
-            if !("_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
+            if !("fail/syslog_standard/_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
                 # convert the the key-value pairs
                 kv {
                     source => "syslog_sd_params_raw"

--- a/src/logsearch-filters-common/src/logstash-filters/snippets/syslog_standard.conf
+++ b/src/logsearch-filters-common/src/logstash-filters/snippets/syslog_standard.conf
@@ -17,7 +17,7 @@ if !("fail/syslog_standard/_grokparsefailure" in [tags]) {
     # Populate @source.host
     if ([syslog_hostname] == "localhost" ) {
         mutate {
-           add_field => [ "[@source][host]", "%{[@ingestor][received_from]}" ]
+           add_field => [ "[@source][host]", "%{[@shipper][host]}" ]
         }
     } else {
         mutate {

--- a/src/logsearch-filters-common/target/logstash-filters-default.conf
+++ b/src/logsearch-filters-common/target/logstash-filters-default.conf
@@ -3,13 +3,11 @@ if [@type] in ["syslog", "relp"] {
   
   grok {
       match => { "@message" => "(?:%{INT:syslog6587_msglen} )?<%{POSINT:syslog_pri}>(?:%{NONNEGINT:syslog5424_ver} )?(?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:syslog_timestamp}) %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?(:)? %{GREEDYDATA:syslog_message}" }
-      add_field => [ "received_at", "%{@timestamp}" ]
-      add_field => [ "received_from", "%{host}" ]
       add_tag => [ "syslog_standard" ]
-      tag_on_failure => ["_grokparsefailure-syslog_standard"]
+      tag_on_failure => ["fail/syslog_standard/_grokparsefailure"]
   }
   
-  if !("_grokparsefailure-syslog_standard" in [tags]) {
+  if !("fail/syslog_standard/_grokparsefailure" in [tags]) {
       syslog_pri { }
   
       date {
@@ -20,25 +18,19 @@ if [@type] in ["syslog", "relp"] {
       # hostname: handle syslog configurations where hostname is localhost
       if ([syslog_hostname] == "localhost" ) {
           grok {
-              match => { "received_from" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
+              match => { "[@ingestor][received_from]" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
               overwrite => [ "syslog_hostname", "syslog_port" ]
-              tag_on_failure => [ "_grokparsefailure-syslog_standard-hostname"]
+              tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_hostname"]
           }
       }
   
       mutate {
-          replace => [ "@source.host", "%{syslog_hostname}" ]
+          replace => [ "[@source][host]", "%{syslog_hostname}" ]
       }
   
       mutate {
           convert => [ "syslog5424_ver", "integer" ]
           convert => [ "syslog6587_msglen", "integer" ]
-          remove_field => [
-              #"syslog_pri",
-              "syslog_hostname",
-              "syslog_port",
-              "syslog_timestamp"
-          ]
       }
   
       if [syslog5424_ver] == 1 {
@@ -49,7 +41,7 @@ if [@type] in ["syslog", "relp"] {
               overwrite => [
                   "syslog_message"
               ]
-              tag_on_failure => [ "_grokparsefailure-syslog_standard-5424" ]
+              tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_standard-5424" ]
           }
   
           # structured-data
@@ -59,10 +51,10 @@ if [@type] in ["syslog", "relp"] {
                   remove_field => [
                       "syslog_sd"
                   ]
-                  tag_on_failure => [ "_grokparsefailure-syslog_standard-5424/sds" ]
+                  tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_standard-5424/sds" ]
               }
   
-              if !("_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
+              if !("fail/syslog_standard/_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
                   # convert the the key-value pairs
                   kv {
                       source => "syslog_sd_params_raw"

--- a/src/logsearch-filters-common/target/logstash-filters-default.conf
+++ b/src/logsearch-filters-common/target/logstash-filters-default.conf
@@ -18,7 +18,7 @@ if [@type] in ["syslog", "relp"] {
       # Populate @source.host
       if ([syslog_hostname] == "localhost" ) {
           mutate {
-             add_field => [ "[@source][host]", "%{[@ingestor][received_from]}" ]
+             add_field => [ "[@source][host]", "%{[@shipper][host]}" ]
           }
       } else {
           mutate {

--- a/src/logsearch-filters-common/target/logstash-filters-default.conf
+++ b/src/logsearch-filters-common/target/logstash-filters-default.conf
@@ -15,17 +15,15 @@ if [@type] in ["syslog", "relp"] {
           timezone => "UTC"
       }
   
-      # hostname: handle syslog configurations where hostname is localhost
+      # Populate @source.host
       if ([syslog_hostname] == "localhost" ) {
-          grok {
-              match => { "[@ingestor][received_from]" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
-              overwrite => [ "syslog_hostname", "syslog_port" ]
-              tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_hostname"]
+          mutate {
+             add_field => [ "[@source][host]", "%{[@ingestor][received_from]}" ]
           }
-      }
-  
-      mutate {
-          replace => [ "[@source][host]", "%{syslog_hostname}" ]
+      } else {
+          mutate {
+              add_field => [ "[@source][host]", "%{syslog_hostname}" ]
+          }
       }
   
       mutate {

--- a/src/logsearch-filters-common/target/logstash-filters-default.conf.erb
+++ b/src/logsearch-filters-common/target/logstash-filters-default.conf.erb
@@ -18,7 +18,7 @@ if [@type] in ["syslog", "relp"] {
       # Populate @source.host
       if ([syslog_hostname] == "localhost" ) {
           mutate {
-             add_field => [ "[@source][host]", "%{[@ingestor][received_from]}" ]
+             add_field => [ "[@source][host]", "%{[@shipper][host]}" ]
           }
       } else {
           mutate {

--- a/src/logsearch-filters-common/target/logstash-filters-default.conf.erb
+++ b/src/logsearch-filters-common/target/logstash-filters-default.conf.erb
@@ -3,13 +3,11 @@ if [@type] in ["syslog", "relp"] {
   
   grok {
       match => { "@message" => "(?:%{INT:syslog6587_msglen} )?<%%{POSINT:syslog_pri}>(?:%{NONNEGINT:syslog5424_ver} )?(?:%{SYSLOGTIMESTAMP:syslog_timestamp}|%{TIMESTAMP_ISO8601:syslog_timestamp}) %{SYSLOGHOST:syslog_hostname} %{DATA:syslog_program}(?:\[%{POSINT:syslog_pid}\])?(:)? %{GREEDYDATA:syslog_message}" }
-      add_field => [ "received_at", "%{@timestamp}" ]
-      add_field => [ "received_from", "%{host}" ]
       add_tag => [ "syslog_standard" ]
-      tag_on_failure => ["_grokparsefailure-syslog_standard"]
+      tag_on_failure => ["fail/syslog_standard/_grokparsefailure"]
   }
   
-  if !("_grokparsefailure-syslog_standard" in [tags]) {
+  if !("fail/syslog_standard/_grokparsefailure" in [tags]) {
       syslog_pri { }
   
       date {
@@ -20,25 +18,19 @@ if [@type] in ["syslog", "relp"] {
       # hostname: handle syslog configurations where hostname is localhost
       if ([syslog_hostname] == "localhost" ) {
           grok {
-              match => { "received_from" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
+              match => { "[@ingestor][received_from]" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
               overwrite => [ "syslog_hostname", "syslog_port" ]
-              tag_on_failure => [ "_grokparsefailure-syslog_standard-hostname"]
+              tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_hostname"]
           }
       }
   
       mutate {
-          replace => [ "@source.host", "%{syslog_hostname}" ]
+          replace => [ "[@source][host]", "%{syslog_hostname}" ]
       }
   
       mutate {
           convert => [ "syslog5424_ver", "integer" ]
           convert => [ "syslog6587_msglen", "integer" ]
-          remove_field => [
-              #"syslog_pri",
-              "syslog_hostname",
-              "syslog_port",
-              "syslog_timestamp"
-          ]
       }
   
       if [syslog5424_ver] == 1 {
@@ -49,7 +41,7 @@ if [@type] in ["syslog", "relp"] {
               overwrite => [
                   "syslog_message"
               ]
-              tag_on_failure => [ "_grokparsefailure-syslog_standard-5424" ]
+              tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_standard-5424" ]
           }
   
           # structured-data
@@ -59,10 +51,10 @@ if [@type] in ["syslog", "relp"] {
                   remove_field => [
                       "syslog_sd"
                   ]
-                  tag_on_failure => [ "_grokparsefailure-syslog_standard-5424/sds" ]
+                  tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_standard-5424/sds" ]
               }
   
-              if !("_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
+              if !("fail/syslog_standard/_grokparsefailure-syslog_standard-5424/sd" in [tags]) {
                   # convert the the key-value pairs
                   kv {
                       source => "syslog_sd_params_raw"

--- a/src/logsearch-filters-common/target/logstash-filters-default.conf.erb
+++ b/src/logsearch-filters-common/target/logstash-filters-default.conf.erb
@@ -15,17 +15,15 @@ if [@type] in ["syslog", "relp"] {
           timezone => "UTC"
       }
   
-      # hostname: handle syslog configurations where hostname is localhost
+      # Populate @source.host
       if ([syslog_hostname] == "localhost" ) {
-          grok {
-              match => { "[@ingestor][received_from]" => "%{IPORHOST:syslog_hostname}(?::%{POSINT:syslog_port})?" }
-              overwrite => [ "syslog_hostname", "syslog_port" ]
-              tag_on_failure => [ "fail/syslog_standard/_grokparsefailure-syslog_hostname"]
+          mutate {
+             add_field => [ "[@source][host]", "%{[@ingestor][received_from]}" ]
           }
-      }
-  
-      mutate {
-          replace => [ "[@source][host]", "%{syslog_hostname}" ]
+      } else {
+          mutate {
+              add_field => [ "[@source][host]", "%{syslog_hostname}" ]
+          }
       }
   
       mutate {

--- a/src/logsearch-filters-common/test/logstash-filters/snippets/syslog_standard-spec.rb
+++ b/src/logsearch-filters-common/test/logstash-filters/snippets/syslog_standard-spec.rb
@@ -11,10 +11,12 @@ describe LogStash::Filters::Grok do
   CONFIG
 
   describe "Accepting standard syslog message without PID specified" do
-    sample("@ingestor" => { "received_from" => "1.2.3.4:12345" } , "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
+    sample("@ingestor" => { "received_from" => "1.2.3.4" } , "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T02:05:03.000Z")
+      
       insist { subject['@source']['host'] } == '1.2.3.4'
+      insist { subject['syslog_hostname'] } == 'localhost'
 
       insist { subject['syslog_facility'] } == 'security/authorization'
       insist { subject['syslog_facility_code'] } == 10
@@ -30,7 +32,9 @@ describe LogStash::Filters::Grok do
     sample("@ingestor" => { "received_from" => "1.2.3.4" }, "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T04:03:06.000Z")
+      
       insist { subject['@source']['host'] } == '1.2.3.4'
+      insist { subject['syslog_hostname'] } == 'localhost'
 
       insist { subject['syslog_facility'] } == 'clock'
       insist { subject['syslog_facility_code'] } == 9

--- a/src/logsearch-filters-common/test/logstash-filters/snippets/syslog_standard-spec.rb
+++ b/src/logsearch-filters-common/test/logstash-filters/snippets/syslog_standard-spec.rb
@@ -11,7 +11,7 @@ describe LogStash::Filters::Grok do
   CONFIG
 
   describe "Accepting standard syslog message without PID specified" do
-    sample("@ingestor" => { "received_from" => "1.2.3.4" } , "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
+    sample("@shipper" => { "host" => "1.2.3.4" } , "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T02:05:03.000Z")
       
@@ -29,7 +29,7 @@ describe LogStash::Filters::Grok do
   end
 
   describe "Accepting standard syslog message with PID specified" do
-    sample("@ingestor" => { "received_from" => "1.2.3.4" }, "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
+    sample("@shipper" => { "host" => "1.2.3.4" }, "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T04:03:06.000Z")
       
@@ -50,7 +50,9 @@ describe LogStash::Filters::Grok do
     sample("host" => "1.2.3.4", "@message" => '<14>2014-04-23T23:19:01.227366+00:00 172.31.201.31 vcap.nats [job=vcap.nats index=1]  {\"timestamp\":1398295141.227022}') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T23:19:01.227Z")
+      
       insist { subject['@source']['host'] } == '172.31.201.31'
+      insist { subject['syslog_hostname'] } == '172.31.201.31'
 
       insist { subject['syslog_facility'] } == 'user-level'
       insist { subject['syslog_facility_code'] } == 1
@@ -72,9 +74,11 @@ describe LogStash::Filters::Grok do
     sample('host' => 'rspec', '@message' => '276 <14>1 2014-05-20T20:40:49+00:00 loggregator d5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc [App/0] - - {"@timestamp":"2014-05-20T20:40:49.907Z","message":"LowRequestRate 2014-05-20T15:44:58.794Z","@source.name":"watcher-bot-ppe","logger":"logsearch_watcher_bot.Program","level":"WARN"}') do
       insist { subject["tags"] } === [ 'syslog_standard' ]
       insist { subject["@timestamp"] } === Time.iso8601("2014-05-20T20:40:49Z")
-      insist { subject['@source']['host'] } === 'loggregator'
-      insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
 
+      insist { subject['@source']['host'] } === 'loggregator'
+      insist { subject['syslog_hostname'] } == 'loggregator'
+
+      insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
       insist { subject['syslog6587_msglen'] } === 276
       insist { subject['syslog5424_ver'] } === 1
       insist { subject['syslog_severity_code'] } === 6
@@ -90,9 +94,11 @@ describe LogStash::Filters::Grok do
     sample('host' => 'rspec', '@message' => '167 <14>1 2014-05-20T09:46:16+00:00 loggregator d5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc [App/0] - - Updating AppSettings for /home/vcap/app/logsearch-watcher-bot.exe.config') do
       insist { subject["tags"] } === [ 'syslog_standard' ]
       insist { subject["@timestamp"] } === Time.iso8601("2014-05-20T09:46:16Z")
-      insist { subject['@source']['host'] } === 'loggregator'
-      insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
 
+      insist { subject['@source']['host'] } === 'loggregator'
+      insist { subject['syslog_hostname'] } == 'loggregator'
+
+      insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
       insist { subject['syslog6587_msglen'] } === 167
       insist { subject['syslog5424_ver'] } === 1
       insist { subject['syslog_severity_code'] } === 6
@@ -108,9 +114,11 @@ describe LogStash::Filters::Grok do
     sample('host' => 'rspec', '@message' => '94 <11>1 2014-05-20T09:46:07+00:00 loggregator d5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc [App/0] - -') do
       insist { subject["tags"] } === [ 'syslog_standard' ]
       insist { subject["@timestamp"] } === Time.iso8601("2014-05-20T09:46:07Z")
-      insist { subject['@source']['host'] } === 'loggregator'
-      insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
 
+      insist { subject['@source']['host'] } === 'loggregator'
+      insist { subject['syslog_hostname'] } == 'loggregator'
+
+      insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
       insist { subject['syslog6587_msglen'] } === 94
       insist { subject['syslog5424_ver'] } === 1
       insist { subject['syslog_severity_code'] } === 3

--- a/src/logsearch-filters-common/test/logstash-filters/snippets/syslog_standard-spec.rb
+++ b/src/logsearch-filters-common/test/logstash-filters/snippets/syslog_standard-spec.rb
@@ -11,10 +11,10 @@ describe LogStash::Filters::Grok do
   CONFIG
 
   describe "Accepting standard syslog message without PID specified" do
-    sample("host" => "1.2.3.4:12345", "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
+    sample("@ingestor" => { "received_from" => "1.2.3.4:12345" } , "@message" => '<85>Apr 24 02:05:03 localhost sudo: bosh_h5156e598 : TTY=pts/0 ; PWD=/var/vcap/bosh_ssh/bosh_h5156e598 ; USER=root ; COMMAND=/bin/pwd') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T02:05:03.000Z")
-      insist { subject['@source.host'] } == '1.2.3.4'
+      insist { subject['@source']['host'] } == '1.2.3.4'
 
       insist { subject['syslog_facility'] } == 'security/authorization'
       insist { subject['syslog_facility_code'] } == 10
@@ -27,10 +27,10 @@ describe LogStash::Filters::Grok do
   end
 
   describe "Accepting standard syslog message with PID specified" do
-    sample("host" => "1.2.3.4", "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
+    sample("@ingestor" => { "received_from" => "1.2.3.4" }, "@message" => '<78>Apr 24 04:03:06 localhost crontab[32185]: (root) LIST (root)') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("#{Time.now.year}-04-24T04:03:06.000Z")
-      insist { subject['@source.host'] } == '1.2.3.4'
+      insist { subject['@source']['host'] } == '1.2.3.4'
 
       insist { subject['syslog_facility'] } == 'clock'
       insist { subject['syslog_facility_code'] } == 9
@@ -46,7 +46,7 @@ describe LogStash::Filters::Grok do
     sample("host" => "1.2.3.4", "@message" => '<14>2014-04-23T23:19:01.227366+00:00 172.31.201.31 vcap.nats [job=vcap.nats index=1]  {\"timestamp\":1398295141.227022}') do
       insist { subject["tags"] } == [ 'syslog_standard' ]
       insist { subject["@timestamp"] } == Time.iso8601("2014-04-23T23:19:01.227Z")
-      insist { subject['@source.host'] } == '172.31.201.31'
+      insist { subject['@source']['host'] } == '172.31.201.31'
 
       insist { subject['syslog_facility'] } == 'user-level'
       insist { subject['syslog_facility_code'] } == 1
@@ -60,7 +60,7 @@ describe LogStash::Filters::Grok do
 
   describe "Invalid syslog message" do
     sample("host" => "1.2.3.4", "@message" => '<78>Apr 24, this message should fail') do
-      insist { subject["tags"] } == [ '_grokparsefailure-syslog_standard' ]
+      insist { subject["tags"] } == [ 'fail/syslog_standard/_grokparsefailure' ]
     end
   end
 
@@ -68,7 +68,7 @@ describe LogStash::Filters::Grok do
     sample('host' => 'rspec', '@message' => '276 <14>1 2014-05-20T20:40:49+00:00 loggregator d5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc [App/0] - - {"@timestamp":"2014-05-20T20:40:49.907Z","message":"LowRequestRate 2014-05-20T15:44:58.794Z","@source.name":"watcher-bot-ppe","logger":"logsearch_watcher_bot.Program","level":"WARN"}') do
       insist { subject["tags"] } === [ 'syslog_standard' ]
       insist { subject["@timestamp"] } === Time.iso8601("2014-05-20T20:40:49Z")
-      insist { subject['@source.host'] } === 'loggregator'
+      insist { subject['@source']['host'] } === 'loggregator'
       insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
 
       insist { subject['syslog6587_msglen'] } === 276
@@ -81,15 +81,12 @@ describe LogStash::Filters::Grok do
       insist { subject['syslog_procid'] } == '[App/0]'
       insist { subject['syslog_msgid'] } == '-'
       insist { subject['syslog_message'] } == '{"@timestamp":"2014-05-20T20:40:49.907Z","message":"LowRequestRate 2014-05-20T15:44:58.794Z","@source.name":"watcher-bot-ppe","logger":"logsearch_watcher_bot.Program","level":"WARN"}'
-
-      insist { subject['received_at'] }.class == Time
-      insist { subject['received_from'] } == 'rspec'
     end
 
     sample('host' => 'rspec', '@message' => '167 <14>1 2014-05-20T09:46:16+00:00 loggregator d5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc [App/0] - - Updating AppSettings for /home/vcap/app/logsearch-watcher-bot.exe.config') do
       insist { subject["tags"] } === [ 'syslog_standard' ]
       insist { subject["@timestamp"] } === Time.iso8601("2014-05-20T09:46:16Z")
-      insist { subject['@source.host'] } === 'loggregator'
+      insist { subject['@source']['host'] } === 'loggregator'
       insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
 
       insist { subject['syslog6587_msglen'] } === 167
@@ -102,15 +99,12 @@ describe LogStash::Filters::Grok do
       insist { subject['syslog_procid'] } == '[App/0]'
       insist { subject['syslog_msgid'] } == '-'
       insist { subject['syslog_message'] } == 'Updating AppSettings for /home/vcap/app/logsearch-watcher-bot.exe.config'
-
-      insist { subject['received_at'] }.class == Time
-      insist { subject['received_from'] } == 'rspec'
     end
 
     sample('host' => 'rspec', '@message' => '94 <11>1 2014-05-20T09:46:07+00:00 loggregator d5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc [App/0] - -') do
       insist { subject["tags"] } === [ 'syslog_standard' ]
       insist { subject["@timestamp"] } === Time.iso8601("2014-05-20T09:46:07Z")
-      insist { subject['@source.host'] } === 'loggregator'
+      insist { subject['@source']['host'] } === 'loggregator'
       insist { subject['syslog_program'] } === 'd5a5e8a5-9b06-4dd3-8157-e9bd3327b9dc'
 
       insist { subject['syslog6587_msglen'] } === 94
@@ -123,9 +117,6 @@ describe LogStash::Filters::Grok do
       insist { subject['syslog_procid'] } == '[App/0]'
       insist { subject['syslog_msgid'] } == '-'
       insist { subject['syslog_message'] } == '-'
-
-      insist { subject['received_at'] }.class == Time
-      insist { subject['received_from'] } == 'rspec'
     end
   end
 


### PR DESCRIPTION
This PR:
1.  Ensures that `@shipper.host` is always populated with the address of the machine sending the data.
2.  When `logstash.metadata_level` == `DEBUG`, adds
   - `@ingestor.timestamp` 
   - `@ingestor.service` 
   - `@ingestor.job` 
3.  Removes `host`, `received_at`, `received_from` (since these are captured by `@shipper.host` and @ingestor.timestamp`
4.  Ensures `@shipper`, `@source` and `@ingestor` are objects (rather than strings with periods in them; which is not allowed in ES 2.0)
5.  Cleans up the `fail/syslog_standard/*` error tags
6.  Retain the `syslog_hostname` and `syslog_timestamp` fields
