### PR TITLE
Fix curator resource pool

### DIFF
--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -139,7 +139,7 @@ jobs:
   release: logsearch
   templates:
   - name: curator
-  resource_pool: logsearch
+  resource_pool: logsearch_api
   networks:
   - name: default
     default:


### PR DESCRIPTION
Resource pool: `logsearch` [does not exist anymore](https://github.com/logsearch/logsearch-boshrelease/blob/develop/templates/logsearch-deployment.yml#L38-L67).
