### PR TITLE
Drop unused elasticsearch.indices.ttl_default job property

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -48,9 +48,6 @@ properties:
   elasticsearch.discovery.minimum_master_nodes:
     description: The minimum number of master eligible nodes a node should "see" in order to operate within the cluster. Recommended to set it to a higher value than 1 when running more than 2 nodes in the cluster.
     default: 1
-  elasticsearch.indices.ttl_default:
-    description: "Default ttl for new documents. Time units: d (days), m (minutes), h (hours), ms (milliseconds) or w (weeks)"
-    default: 30d
   elasticsearch.config_options:
     description: "Additional options to append to elasticsearch's config.yml (YAML format)."
     default: ~


### PR DESCRIPTION
Issue #189
