### PR TITLE
Added logsearch_curator resource pool

### DIFF
--- a/templates/logsearch-deployment.yml
+++ b/templates/logsearch-deployment.yml
@@ -66,3 +66,8 @@ resource_pools:
   cloud_properties: ~
   env: (( merge || meta.default_env ))
 
+- name: logsearch_curator
+  network: default
+  stemcell: (( meta.stemcell ))
+  cloud_properties: ~
+  env: (( merge || meta.default_env ))

--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -139,7 +139,7 @@ jobs:
   release: logsearch
   templates:
   - name: curator
-  resource_pool: logsearch
+  resource_pool: logsearch_curator
   networks:
   - name: default
     default:


### PR DESCRIPTION
Resource pool for `curator` job was defined as `logsearch`, but there was no such resource pool.
