### PR TITLE
Add ulimit for mem

### DIFF
--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -59,6 +59,7 @@ case $1 in
     /var/vcap/jobs/elasticsearch/bin/undrain 2>&1 >> $LOG_DIR/undrain.log &
 
     ulimit -n 64000
+    ulimit -l unlimited
 
     exec chpst -u vcap:vcap /var/vcap/packages/elasticsearch/bin/elasticsearch \
          -Des.config=${JOB_DIR}/config/config.yml \


### PR DESCRIPTION
Hi guys,
this quick fix allows to get rid of annoying warning `Unable to lock JVM memory (ENOMEM). This can result in part of the JVM being swapped out. Increase RLIMIT_MEMLOCK (ulimit).` when ElasticSearch starting
