### PR TITLE
Added support for configuring elasticsearch http.host property

### DIFF
--- a/jobs/elasticsearch/spec
+++ b/jobs/elasticsearch/spec
@@ -53,3 +53,6 @@ properties:
   elasticsearch.plugins:
     description: "Plugins to run elasticsearch with (array[] = { plugin-name: install-source }; e.g. [ { kopf: 'lmenezes/elasticsearch-kopf' } ])"
     default: []
+  elasticsearch.http_host:
+    description: "The host address to bind the elasticsearch HTTP service to and to publish for HTTP clients to connect to"
+    default: 0.0.0.0

--- a/jobs/elasticsearch/templates/config/config.yml.erb
+++ b/jobs/elasticsearch/templates/config/config.yml.erb
@@ -18,6 +18,7 @@ node.<%= k %>: "<%= v %>"
 <% end %>
 
 network.host: "0.0.0.0"
+http.host: <%= p("elasticsearch.http_host") %>
 
 discovery.zen.minimum_master_nodes: <%= p("elasticsearch.discovery.minimum_master_nodes") %>
 discovery.zen.ping.multicast.enabled: false


### PR DESCRIPTION
We would like to be able to configure the elasticsearch `http.host` property. This allows us to better control the external visibility of the HTTP service exposed by elasticsearch. For example, by specifying "127.0.0.1" we can make it visible only by other processes running on the same host, e.g. a reverse proxy.
