### PR TITLE
Added support for configuring kibana server.host property

### DIFF
--- a/jobs/kibana/spec
+++ b/jobs/kibana/spec
@@ -22,6 +22,9 @@ properties:
   kibana.port:
     description: "Kibana is served by a back end server. This controls which port to use."
     default: 5601
+  kibana.host:
+    description: "This setting specifies the IP address of the back end server."
+    default: "0.0.0.0"
   kibana.request_timeout:
     description: "Time in milliseconds to wait for responses from the back end or elasticsearch.  This must be > 0"
     default: 300000

--- a/jobs/kibana/templates/config/kibana.conf.erb
+++ b/jobs/kibana/templates/config/kibana.conf.erb
@@ -2,7 +2,7 @@
 server.port: <%= p('kibana.port') %>
 
 # The host to bind the server to.
-# server.host: "0.0.0.0"
+server.host: <%= p('kibana.host') %>
 
 # If you are running kibana behind a proxy, and want to mount it at a path,
 # specify that path here. The basePath can't end in a slash.
@@ -79,4 +79,3 @@ elasticsearch.shardTimeout: <%= p('kibana.shard_timeout') %>
 
 # Set this to true to log all events, including system usage information and all requests.
 # logging.verbose: false
-


### PR DESCRIPTION
We would like to be able to configure the Kibana `server.host` property. This allows us to better control the external visibility of the HTTP service exposed by Kibana. For example, by specifying "127.0.0.1" we can make it visible only by other processes running on the same host, e.g. a reverse proxy.
