### PR TITLE
Added support for configuring redis memory settings

### DIFF
--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -18,8 +18,9 @@ properties:
     description: Name of queue to pull messages from
     default: logstash
   redis.maxmemory:
-    description: Maximum amount of memory in bytes to be used by Redis.
+    description: Maximum amount of memory to be used by Redis. The default value NINETY_PERCENT_OF_RAM is an environment variable initialized in redis_ctl. Typically you would specify an exact value in bytes.
+    example: 8523874304
     default: NINETY_PERCENT_OF_RAM
   redis.maxmemory-policy:
-    description: How Redis will select what to remove when maxmemory is reached.
-    default: volatile-lru 
+    description: How Redis will select what to remove when maxmemory is reached. Possible values are volatile-lru, allkeys-lru, volatile-random, allkeys-random, volatile-ttl, and noeviction.
+    default: volatile-lru

--- a/jobs/queue/spec
+++ b/jobs/queue/spec
@@ -1,6 +1,6 @@
 ---
 name: queue
-packages: 
+packages:
 - redis
 templates:
   bin/redis_ctl: bin/redis_ctl
@@ -11,9 +11,15 @@ templates:
   config/redis.conf.erb: config/redis.conf
   logsearch/metric-collector/redis/collector: logsearch/metric-collector/redis/collector
 properties:
-  redis.port: 
+  redis.port:
     description: Redis port of queue
     default: 6379
   redis.key:
     description: Name of queue to pull messages from
     default: logstash
+  redis.maxmemory:
+    description: Maximum amount of memory in bytes to be used by Redis.
+    default: NINETY_PERCENT_OF_RAM
+  redis.maxmemory-policy:
+    description: How Redis will select what to remove when maxmemory is reached.
+    default: volatile-lru 

--- a/jobs/queue/templates/config/redis.conf.erb
+++ b/jobs/queue/templates/config/redis.conf.erb
@@ -393,7 +393,7 @@ slave-priority 100
 # limit for maxmemory so that there is some free RAM on the system for slave
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
-maxmemory NINETY_PERCENT_OF_RAM
+maxmemory <%= p("redis.maxmemory") %>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached. You can select among five behaviors:
@@ -416,7 +416,7 @@ maxmemory NINETY_PERCENT_OF_RAM
 #
 # The default is:
 #
-# maxmemory-policy volatile-lru
+maxmemory-policy <%= p("redis.maxmemory-policy") %>
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample


### PR DESCRIPTION
We would like to be able to configure the Redis memory settings for the `queue` job, in particular the 2 properties `maxmemory` and `maxmemory-policy`. We had actual issues with Redis consuming too much memory in some of our deployments. Without being able to specify these settings, we wouldn't be able to solve them.
