### PR TITLE
Remove duplicate update definitions in jobs

### DIFF
--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -4,8 +4,6 @@ jobs:
   templates:
   - {name: elasticsearch, release: logsearch}
   resource_pool: elasticsearch_master
-  update:
-    serial: true
   instances: 1
   networks:
   - name: default
@@ -133,8 +131,6 @@ jobs:
   templates:
   - {name: elasticsearch, release: logsearch}
   resource_pool: elasticsearch_data
-  update:
-    serial: true
   instances: 2
   networks:
   - name: default


### PR DESCRIPTION
YAML permits only one definition of hash. The 2nd definition is over-
riding the 1st one, which then never takes effect. Remove the 1st
definition to remove potential confusion.
