### PR TITLE
Don't run ELS on parser

### DIFF
--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -175,7 +175,6 @@ jobs:
   release: logsearch
   templates:
   - {name: parser, release: logsearch}
-  - {name: elasticsearch, release: logsearch}
   resource_pool: parser
   instances: 1
   networks:


### PR DESCRIPTION
There is already elasticsearch deployed as a part of parser job. No
need to run another elasticsearch on the same VM. Moreover, ELS is
configured to consume 46% of the VM memory, which in case of 2 ELSes
means that the VM runs out of memory, starts swapping heavily and
becomes unresponsive.
