### PR TITLE
Increase elasticsearch start timeout

### DIFF
--- a/jobs/elasticsearch/monit
+++ b/jobs/elasticsearch/monit
@@ -1,6 +1,6 @@
 check process elasticsearch
   with pidfile /var/vcap/sys/run/elasticsearch/elasticsearch.pid
-  start program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl start'"
+  start program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl start'" with timeout 120 seconds
   stop program "/var/vcap/jobs/elasticsearch/bin/monit_debugger elasticsearch_ctl '/var/vcap/jobs/elasticsearch/bin/elasticsearch_ctl stop'"
   group vcap
 


### PR DESCRIPTION
We're installing a few plugins into Elasticsearch by configuring them in `elasticsearch.plugins`:

```
properties:
  elasticsearch:
    plugins:
    - license: license
    - shield: shield
    - cloud-aws: cloud-aws
    - marvel: marvel-agent
```

At this point Elasticsearch takes well past 30 seconds to create its pidfile and monit gives up on it every time.

I saw in 96002b3 that the plugin installation was deliberately moved to a different pidfile, so I thought I'd address it by increasing the start timeout. I timed it; on an m3.medium this set of plugins delays startup of Elasticsearch by about 45 seconds, so I rounded to 60 and doubled it out of caution.
