### PR TITLE
elasticsearch_data job should use dynamic IPs

### DIFF
--- a/templates/logsearch-jobs.yml
+++ b/templates/logsearch-jobs.yml
@@ -119,7 +119,6 @@ jobs:
   persistent_disk_pool: elasticsearch_data
   networks:
   - name: default
-    static_ips: (( static_ips(16, 17) ))
   properties:
     elasticsearch:
       node:


### PR DESCRIPTION
when I scale out the es cluster, I don't want to worry about finding extra static IPs, just bump the instance number and deploy.
