### PR TITLE
Limit the number of messages that can be sent to the queue

### DIFF
--- a/jobs/ingestor_syslog/spec
+++ b/jobs/ingestor_syslog/spec
@@ -55,6 +55,12 @@ properties:
   redis.key: 
     description: Name of queue to pull messages from
     default: logstash
+  redis.congestion_interval:
+    description: How often to check for queue length. Default is one second. Zero means to check on every message
+    default: 10
+  redis.congestion_threshold:
+    description: Max number of messages to allow in the queue.  Will stop (and drop) ingesting new messages when this is reached
+    default: 1000000
 
   archiver.enabled:
     default: false

--- a/jobs/ingestor_syslog/templates/config/logstash.conf.erb
+++ b/jobs/ingestor_syslog/templates/config/logstash.conf.erb
@@ -68,7 +68,9 @@ output {
                   "data_type" => "list",
                   "key" => p('redis.key'),
                   "batch" => true,
-                  "batch_events" => 50
+                  "batch_events" => 50,
+                  "congestion_interval" => p('redis.congestion_interval'),
+                  "congestion_threshold" => p('redis.congestion_threshold')
                 } %>
               <% end %>
 	      <% output['options'].each do | k, v | %>


### PR DESCRIPTION
Newer version of the [`logstash redis output come with congestion settings`](https://www.elastic.co/guide/en/logstash/current/plugins-outputs-redis.html#plugins-outputs-redis-congestion_threshold) that can be used to prevent logstash from overloading redis.

This PR adds configuration options to the ingestor_syslog job that limit the number of messages it will place on the queue to 100,000
