### PR TITLE
Ensure elasticsearch is receiving requests in ctl script before exiting

### DIFF
--- a/jobs/elasticsearch/templates/bin/elasticsearch_ctl
+++ b/jobs/elasticsearch/templates/bin/elasticsearch_ctl
@@ -64,6 +64,17 @@ case $1 in
          <%= p("elasticsearch.exec.options", []).join(' ') %> \
          >>$LOG_DIR/$JOB_NAME.stdout.log \
          2>>$LOG_DIR/$JOB_NAME.stderr.log
+
+    # Ensure ES is receiving connections before exiting ctl script
+    count=0
+    curl 'http://localhost:9200'
+    while [[ $count -le 3600  && $? -ne 0 ]]
+    do
+        sleep 1
+        (( count++ ))
+        curl 'http://localhost:9200'
+    done
+
     ;;
 
   stop)


### PR DESCRIPTION
Sometimes when doing a bosh deploy we have ran into an issue where the master node will deploy and report back healthy, then bosh will continue on to deploy the data nodes which will fail because the master is not accepting connections yet.

This change ensures that the elasticsearch node is accepting connections before continuing
