### PR TITLE
Fix generate_deployment_manifest usage

### DIFF
--- a/scripts/generate_deployment_manifest
+++ b/scripts/generate_deployment_manifest
@@ -12,7 +12,7 @@ if [ "$infrastructure" != "aws" ] && \
     [ "$infrastructure" != "openstack" ] && \
     [ "$infrastructure" != "warden" ] && \
     [ "$infrastructure" != "vsphere" ] ; then
-  echo "usage: ./generate_deployment_manifest <aws|openstack|warden|vsphere> [stubs...]"
+  echo "usage: ./generate_deployment_manifest <aws|openstack|warden|vsphere> [stubs...]" 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
Hi!
I updated `generate_deployment_manifest` to write in stdout in case of misspelling or wrong usage, it was annoying to find `echo "usage: ./generate_deployment_manifest <aws|openstack|warden|vsphere> [stubs...]"` inside of my deployment manifest.
Also i can propose to delete Spruce binary from logsearch-boshrelease repo and instead of it add simple check into `generate_deployment_manifest` script for Spruce installation. 
@mrdavidlaing What is your opinion on this? If you agree, than i can add additional commit to current PR.
Thanks!
