### PR TITLE
Added Elasticsearch web access

### DIFF
--- a/jobs/haproxy/spec
+++ b/jobs/haproxy/spec
@@ -64,6 +64,18 @@ properties:
     description: "Basic auth password for kibana. Optional"
     default: ""
 
+  haproxy.elastic.inbound_port:
+    description: "The public port for Elasticsearch interface. IMPORTANT: Do not set this value unless you understand what are you doing! External access to Elasticsearch allows to do everything with it, including index deletion. Once enabled this feature, it is strictly recommended to set the password below."
+  haproxy.elastic.backend_servers:
+    description: "Lish of Elasticsearch nodes"
+    default: []
+  haproxy.elastic.auth.username:
+    description: "Basic auth username for Elasticsearch. Optional"
+    default: ""
+  haproxy.elastic.auth.password:
+    description: "Basic auth password for Elasticsearch. Optional"
+    default: ""
+
   haproxy.cluster_monitor.inbound_port:
     description: "The public port of the cluster monitor UI"
     default: 8080

--- a/jobs/haproxy/templates/haproxy.config.erb
+++ b/jobs/haproxy/templates/haproxy.config.erb
@@ -82,6 +82,37 @@ backend cluster_monitor
     server kibana<%= index %> <%= ip %>:<%= p("haproxy.cluster_monitor.backend_port") %> check inter 1000
     <% end %>
 
+<% if p('properties.haproxy.elastic.inbound_port') %>
+frontend elastic-in
+    mode http
+
+    <% if p('properties.haproxy.ssl_pem') %>
+    bind :<%= p("haproxy.elastic.inbound_port") %> ssl crt /var/vcap/jobs/haproxy/config/cert.pem no-sslv3
+    <% else %>
+    bind :<%= p("haproxy.elastic.inbound_port") %>
+    <% end %>
+
+    <% if p('haproxy.elastic.auth.username') != "" %>
+    acl logged_in http_auth(elastic-user)
+    http-request auth realm "Elasticsearch" if !logged_in
+    <% end %>
+
+    default_backend elastic
+
+backend elastic
+    mode http
+    balance roundrobin
+    <% p("haproxy.elastic.backend_servers").each_with_index do |ip, index| %>
+    server elastic<%= index %> <%= ip %>:9200 check inter 1000
+    <% end %>
+
+<% if p('haproxy.elastic.auth.username') != "" %>
+userlist elastic-user
+    user <%= p('haproxy.elastic.auth.username') %> insecure-password <%= p('haproxy.elastic.auth.password') %>
+<% end %>
+
+<% end %>
+
 <% if p('haproxy.kibana.auth.username') != "" %>
 userlist kibana-user
     user <%= p('haproxy.kibana.auth.username') %> insecure-password <%= p('haproxy.kibana.auth.password') %>


### PR DESCRIPTION
Hi,
this PR is adding ability to access Elasticsearch interface from the browser. This is very useful for Kopf, for example.
Here is an example of properties for `ls-router` job for using it:

```
  properties:
    haproxy:
      elastic:
        inbound_port: 8888    # Must specify the port to enable access to Elasticsearch
        backend_servers:
        - (( grab jobs.elasticsearch_master.networks.default.static_ips.[0] ))
        auth:
          username: user
          password: pass
```
